### PR TITLE
Add Avian2D Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,14 @@ name = "infinite_rapier"
 required-features = ["rapier_debug"]
 
 [[example]]
+name = "finite_avian"
+required-features = ["avian"]
+
+[[example]]
+name = "infinite_avian"
+required-features = ["avian"]
+
+[[example]]
 name = "hex_map"
 
 [[example]]
@@ -90,12 +98,20 @@ name = "controller_rapier"
 required-features = ["rapier_debug"]
 
 [[example]]
+name = "controller_avian"
+required-features = ["avian"]
+
+[[example]]
 name = "user_properties"
 required-features = ["user_properties"]
 
 [[example]]
 name = "user_properties_rapier"
-required-features = ["user_properties","rapier_debug"]
+required-features = ["user_properties", "rapier_debug"]
+
+[[example]]
+name = "user_properties_avian"
+required-features = ["user_properties", "avian"]
 
 [[example]]
 name = "isometric_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = ["bevy_ecs_tilemap/serde"]
 physics = []
 rapier = ["bevy_rapier2d", "physics"]
 rapier_debug = ["rapier", "bevy_rapier2d/debug-render-2d"]
+avian = ["dep:avian2d", "physics"]
 
 # WASM
 wasm = ["bevy_rapier2d/wasm-bindgen", "tiled/wasm"]
@@ -42,16 +43,20 @@ thiserror = "1.0.62"
 tiled = "0.12.0"
 
 # Optional dependencies, enabled via features.
-bevy_rapier2d = {version = "0.27.0", optional = true}
+bevy_rapier2d = { version = "0.27.0", optional = true }
+avian2d = { version = "0.1.1", optional = true }
 bevy_ecs_tiled_macros = { version = "0.1.0", optional = true, path = "macros" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-bevy_rapier2d = {version = "0.27.0", features = ["wasm-bindgen"], optional = true}
-tiled = {version = "0.12.0", features = ["wasm"]}
+bevy_rapier2d = { version = "0.27.0", features = [
+    "wasm-bindgen",
+], optional = true }
+tiled = { version = "0.12.0", features = ["wasm"] }
 
 [dev-dependencies]
 bevy-inspector-egui = "0.25.1"
-bevy_rapier2d = {version = "0.27.0", features = ["debug-render-2d"]}
+bevy_rapier2d = { version = "0.27.0", features = ["debug-render-2d"] }
+avian2d = "0.1.1"
 log = "0.4"
 
 [[example]]

--- a/examples/controller_avian.rs
+++ b/examples/controller_avian.rs
@@ -15,6 +15,7 @@ fn main() {
         .add_plugins(helper::HelperPlugin)
         .add_plugins(PhysicsPlugins::default().with_length_unit(100.0))
         .add_plugins(PhysicsDebugPlugin::default())
+        .insert_resource(Gravity(Vec2::NEG_Y * 1000.0))
         .add_systems(Startup, startup)
         .run();
 }
@@ -29,10 +30,10 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             // This is the default, but we're setting it explicitly here for clarity.
             collision_object_names: ObjectNames::All,
             // By default, colliders are added without associated RigidBody
-            // for this example, let's add a RigidBody::Kinematic
+            // for this example, let's add a RigidBody::Static
             // you can also add any physic related component using this mecanism
             collider_callback: |entity_commands| {
-                entity_commands.insert(RigidBody::Kinematic);
+                entity_commands.insert(RigidBody::Static);
             },
             ..default()
         },

--- a/examples/controller_avian.rs
+++ b/examples/controller_avian.rs
@@ -1,0 +1,44 @@
+//! This example shows a simple player-controlled object using Avian2D physics. You can move the object using arrow keys.
+
+use avian2d::prelude::*;
+use bevy::prelude::*;
+use bevy_ecs_tiled::prelude::*;
+use bevy_ecs_tilemap::prelude::*;
+
+mod helper;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TilemapPlugin)
+        .add_plugins(TiledMapPlugin)
+        .add_plugins(helper::HelperPlugin)
+        .add_plugins(PhysicsPlugins::default().with_length_unit(100.0))
+        .add_plugins(PhysicsDebugPlugin::default())
+        .add_systems(Startup, startup)
+        .run();
+}
+
+fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let map_handle: Handle<TiledMap> = asset_server.load("multiple_layers_with_colliders.tmx");
+    commands.spawn(TiledMapBundle {
+        tiled_map: map_handle,
+        tiled_settings: TiledMapSettings {
+            // This is the default, but we're setting it explicitly here for clarity.
+            collision_object_names: ObjectNames::All,
+            // By default, colliders are added without associated RigidBody
+            // for this example, let's add a RigidBody::Kinematic
+            // you can also add any physic related component using this mecanism
+            collider_callback: |entity_commands| {
+                entity_commands.insert(RigidBody::Kinematic);
+            },
+            ..default()
+        },
+        ..Default::default()
+    });
+
+    // Spawn a simple player-controlled object
+    helper::avian::spawn_player(&mut commands, 10., Vec2::new(100., 100.));
+}

--- a/examples/finite_avian.rs
+++ b/examples/finite_avian.rs
@@ -1,0 +1,37 @@
+//! This example shows a finite orthogonal map with an external tileset and Avian2D physics.
+
+use avian2d::prelude::*;
+use bevy::prelude::*;
+use bevy_ecs_tiled::prelude::*;
+use bevy_ecs_tilemap::prelude::*;
+
+mod helper;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TilemapPlugin)
+        .add_plugins(TiledMapPlugin)
+        .add_plugins(helper::HelperPlugin)
+        .add_plugins(PhysicsPlugins::default().with_length_unit(100.0))
+        .add_plugins(PhysicsDebugPlugin::default())
+        .add_systems(Startup, startup)
+        .run();
+}
+
+fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let map_handle: Handle<TiledMap> = asset_server.load("finite.tmx");
+    commands.spawn(TiledMapBundle {
+        tiled_map: map_handle,
+        tiled_settings: TiledMapSettings {
+            // This is the default, but we're setting it explicitly here for clarity.
+            collision_object_names: ObjectNames::All,
+            // Not related to current example, but center the map
+            map_positioning: MapPositioning::Centered,
+            ..default()
+        },
+        ..Default::default()
+    });
+}

--- a/examples/helper/avian.rs
+++ b/examples/helper/avian.rs
@@ -1,0 +1,54 @@
+use avian2d::prelude::*;
+use bevy::prelude::*;
+
+const MOVE_SPEED: f32 = 200.;
+const GRAVITY_SCALE: f32 = 10.0;
+
+#[derive(Default, Clone, Component)]
+pub struct PlayerMarker;
+
+#[allow(unused)]
+pub fn spawn_player(commands: &mut Commands, radius: f32, spawn_position: Vec2) {
+    commands
+        .spawn(RigidBody::Dynamic)
+        .insert(PlayerMarker)
+        .insert(Name::new("PlayerControlledObject (Avian2D physics)"))
+        .insert(Collider::circle(radius))
+        .insert(GravityScale(GRAVITY_SCALE))
+        .insert(TransformBundle::from(Transform::from_xyz(
+            spawn_position.x,
+            spawn_position.y,
+            0.0,
+        )));
+}
+
+pub fn move_player(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut player: Query<&mut LinearVelocity, With<PlayerMarker>>,
+) {
+    for mut rb_vel in player.iter_mut() {
+        let mut direction = Vec2::ZERO;
+
+        if keyboard_input.pressed(KeyCode::ArrowRight) {
+            direction += Vec2::new(1.0, 0.0);
+        }
+
+        if keyboard_input.pressed(KeyCode::ArrowLeft) {
+            direction -= Vec2::new(1.0, 0.0);
+        }
+
+        if keyboard_input.pressed(KeyCode::ArrowUp) {
+            direction += Vec2::new(0.0, 1.0);
+        }
+
+        if keyboard_input.pressed(KeyCode::ArrowDown) {
+            direction -= Vec2::new(0.0, 1.0);
+        }
+
+        if direction != Vec2::ZERO {
+            direction /= direction.length();
+        }
+
+        rb_vel.0 = direction * MOVE_SPEED;
+    }
+}

--- a/examples/helper/mod.rs
+++ b/examples/helper/mod.rs
@@ -7,6 +7,9 @@ mod map;
 #[cfg(feature = "rapier")]
 pub mod rapier;
 
+#[cfg(feature = "avian")]
+pub mod avian;
+
 #[derive(Default)]
 pub struct HelperPlugin;
 
@@ -17,5 +20,7 @@ impl Plugin for HelperPlugin {
         app.add_systems(Update, map::rotate);
         #[cfg(feature = "rapier")]
         app.add_systems(Update, rapier::move_player);
+        #[cfg(feature = "avian")]
+        app.add_systems(Update, avian::move_player);
     }
 }

--- a/examples/infinite_avian.rs
+++ b/examples/infinite_avian.rs
@@ -1,0 +1,36 @@
+//! This example shows an infinite orthogonal map with an external tileset and Avian2D physics.
+
+use avian2d::prelude::*;
+use bevy::prelude::*;
+use bevy_ecs_tiled::prelude::*;
+use bevy_ecs_tilemap::prelude::*;
+
+mod helper;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TilemapPlugin)
+        .add_plugins(TiledMapPlugin)
+        .add_plugins(helper::HelperPlugin)
+        .add_plugins(PhysicsPlugins::default().with_length_unit(100.0))
+        .add_plugins(PhysicsDebugPlugin::default())
+        .add_systems(Startup, startup)
+        .run();
+}
+
+fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let map_handle: Handle<TiledMap> = asset_server.load("infinite.tmx");
+    commands.spawn(TiledMapBundle {
+        tiled_map: map_handle,
+        tiled_settings: TiledMapSettings {
+            // By default `bevy_ecs_tiled` will add colliders for all object layers.
+            // This shows how we can specify exactly which layers and objects to process.
+            collision_object_names: ObjectNames::Names(vec!["collision".to_string()]),
+            ..default()
+        },
+        ..default()
+    });
+}

--- a/examples/user_properties_avian.rs
+++ b/examples/user_properties_avian.rs
@@ -1,9 +1,9 @@
-//! This example shows how to map custom tiles / objects properties from Tiled to Bevy Components and manually spawn Rapier colliders from them.
+//! This example shows how to map custom tiles / objects properties from Tiled to Bevy Components and manually spawn Avian colliders from them.
 
+use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_tiled::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
-use bevy_rapier2d::prelude::*;
 
 mod helper;
 
@@ -13,8 +13,8 @@ fn main() {
         .add_plugins(TilemapPlugin)
         .add_plugins(TiledMapPlugin)
         .add_plugins(helper::HelperPlugin)
-        .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-        .add_plugins(RapierDebugRenderPlugin::default())
+        .add_plugins(PhysicsPlugins::default().with_length_unit(100.0))
+        .add_plugins(PhysicsDebugPlugin::default())
         .add_systems(Startup, startup)
         .add_systems(Update, display_custom_tiles)
         .add_systems(Update, display_objects)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod prelude {
     pub use crate::loader::*;
     pub use crate::names::*;
     #[cfg(feature = "physics")]
-    pub use crate::physics::prelude::*;
+    pub use crate::physics::*;
     #[cfg(feature = "user_properties")]
     pub use crate::properties::prelude::*;
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -39,6 +39,9 @@ use bevy::{
     utils::HashMap,
 };
 
+#[cfg(feature = "physics")]
+use crate::physics::{insert_object_colliders, insert_tile_colliders};
+
 use crate::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
 use tiled::{ChunkData, FiniteTileLayer, InfiniteTileLayer, LayerType, Tile};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -377,7 +377,7 @@ fn load_map(
         )))
         .insert(TiledMapMarker);
 
-    #[cfg(any(feature = "rapier", feature = "avian"))]
+    #[cfg(feature = "physics")]
     let collision_layer_names =
         crate::prelude::ObjectNameFilter::from(&tiled_settings.collision_layer_names);
 
@@ -558,7 +558,7 @@ fn load_map(
                             .set_parent(layer_entity)
                             .id();
 
-                        #[cfg(any(feature = "rapier", feature = "avian"))]
+                        #[cfg(feature = "physics")]
                         {
                             if collision_layer_names.contains(&layer.name.trim().to_lowercase()) {
                                 insert_object_colliders(
@@ -734,7 +734,7 @@ fn load_infinite_tiles_layer(
         bottomright_y
     );
 
-    #[cfg(any(feature = "rapier", feature = "avian"))]
+    #[cfg(feature = "physics")]
     let collision_object_names =
         crate::prelude::ObjectNameFilter::from(&tiled_settings.collision_object_names);
 
@@ -899,7 +899,7 @@ fn handle_special_tile(
     }
 
     // Handle tiles with collision
-    #[cfg(any(feature = "rapier", feature = "avian"))]
+    #[cfg(feature = "physics")]
     {
         if let Some(collision) = tile.collision.as_ref() {
             insert_tile_colliders(

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -377,7 +377,7 @@ fn load_map(
         )))
         .insert(TiledMapMarker);
 
-    #[cfg(feature = "rapier")]
+    #[cfg(any(feature = "rapier", feature = "avian"))]
     let collision_layer_names =
         crate::prelude::ObjectNameFilter::from(&tiled_settings.collision_layer_names);
 
@@ -558,7 +558,7 @@ fn load_map(
                             .set_parent(layer_entity)
                             .id();
 
-                        #[cfg(feature = "rapier")]
+                        #[cfg(any(feature = "rapier", feature = "avian"))]
                         {
                             if collision_layer_names.contains(&layer.name.trim().to_lowercase()) {
                                 insert_object_colliders(
@@ -734,7 +734,7 @@ fn load_infinite_tiles_layer(
         bottomright_y
     );
 
-    #[cfg(feature = "rapier")]
+    #[cfg(any(feature = "rapier", feature = "avian"))]
     let collision_object_names =
         crate::prelude::ObjectNameFilter::from(&tiled_settings.collision_object_names);
 
@@ -899,7 +899,7 @@ fn handle_special_tile(
     }
 
     // Handle tiles with collision
-    #[cfg(feature = "rapier")]
+    #[cfg(any(feature = "rapier", feature = "avian"))]
     {
         if let Some(collision) = tile.collision.as_ref() {
             insert_tile_colliders(

--- a/src/physics/avian.rs
+++ b/src/physics/avian.rs
@@ -1,0 +1,125 @@
+use avian2d::{math::Vector, prelude::*};
+use bevy::prelude::*;
+use bevy_ecs_tilemap::prelude::*;
+use tiled::{ObjectData, ObjectLayerData};
+
+use crate::prelude::*;
+
+/// Load shapes from an object layer as physics colliders.
+///
+/// By default `bevy_ecs_tiled` will only process object layers
+/// named in `collision_layer_names` in `TiledMapSettings`,
+/// and tileset collision shapes named in `collision_object_names`.
+///
+/// Collision layer names are case-insensitive and leading/trailing
+/// whitespace is stripped out.
+pub fn insert_object_colliders(
+    commands: &mut Commands,
+    object_entity: Entity,
+    object_data: &ObjectData,
+    collider_callback: ColliderCallback,
+) {
+    insert_colliders_from_shapes(
+        commands,
+        object_entity,
+        None,
+        object_data,
+        collider_callback,
+    );
+}
+
+pub fn insert_tile_colliders(
+    commands: &mut Commands,
+    collision_object_names: &ObjectNameFilter,
+    tile_entity: Entity,
+    grid_size: &TilemapGridSize,
+    collision: &ObjectLayerData,
+    collider_callback: ColliderCallback,
+) {
+    for object_data in collision.object_data().iter() {
+        if collision_object_names.contains(&object_data.name.trim().to_lowercase()) {
+            insert_colliders_from_shapes(
+                commands,
+                tile_entity,
+                Some(grid_size),
+                object_data,
+                collider_callback,
+            );
+        }
+    }
+}
+
+/// Insert shapes as physics colliders.
+fn insert_colliders_from_shapes(
+    commands: &mut Commands,
+    parent_entity: Entity,
+    grid_size: Option<&TilemapGridSize>,
+    object_data: &ObjectData,
+    collider_callback: ColliderCallback,
+) {
+    let rot = object_data.rotation;
+    let (pos, collider) = match &object_data.shape {
+        tiled::ObjectShape::Rect { width, height } => {
+            // The origin is the top-left corner of the rectangle when not rotated.
+            let shape = Collider::rectangle(*width, *height);
+            let pos = Vector::new(width / 2., -height / 2.);
+            (pos, shape)
+        }
+        tiled::ObjectShape::Ellipse { width, height } => {
+            let shape = Collider::ellipse(width / 2., height / 2.);
+            let pos = Vector::new(width / 2., -height / 2.);
+            (pos, shape)
+        }
+        tiled::ObjectShape::Polyline { points } => {
+            let shape = Collider::polyline(
+                points.iter().map(|(x, y)| Vector::new(*x, -*y)).collect(),
+                None,
+            );
+            (Vector::ZERO, shape)
+        }
+        tiled::ObjectShape::Polygon { points } => {
+            let shape = match Collider::convex_hull(
+                points
+                    .iter()
+                    .map(|(x, y)| Vector::new(*x, -*y))
+                    .collect::<Vec<Vector>>(),
+            ) {
+                Some(x) => x,
+                None => {
+                    return;
+                }
+            };
+
+            (Vector::ZERO, shape)
+        }
+        _ => {
+            return;
+        }
+    };
+
+    let mut translation = Vec3::default();
+    // If we have a grid_size, it means we are adding colliders for a tile:
+    // we need to take into account object position, which are relative to the tile
+    // If we don't have a grid_size, it means we are adding colliders for a standalone object
+    // we need to ignore object position, since our parent should already have the correct position
+    if let Some(grid_size) = grid_size {
+        translation = Vec3::new(
+            object_data.x - grid_size.x / 2.,
+            (grid_size.y - object_data.y) - grid_size.y / 2.,
+            0.,
+        );
+    }
+
+    let transform = Transform {
+        translation,
+        rotation: Quat::from_rotation_z(f32::to_radians(-rot)),
+        ..default()
+    } * Transform::from_translation(Vec3::new(pos.x, pos.y, 0.));
+
+    let mut entity_commands = commands.spawn(collider);
+    entity_commands
+        .insert(TransformBundle::from_transform(transform))
+        .insert(Name::new(format!("Collider({})", object_data.name)))
+        .set_parent(parent_entity);
+    collider_callback(&mut entity_commands);
+}

--- a/src/physics/avian.rs
+++ b/src/physics/avian.rs
@@ -1,56 +1,12 @@
 use avian2d::{math::Vector, prelude::*};
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
-use tiled::{ObjectData, ObjectLayerData};
+use tiled::ObjectData;
 
 use crate::prelude::*;
 
-/// Load shapes from an object layer as physics colliders.
-///
-/// By default `bevy_ecs_tiled` will only process object layers
-/// named in `collision_layer_names` in `TiledMapSettings`,
-/// and tileset collision shapes named in `collision_object_names`.
-///
-/// Collision layer names are case-insensitive and leading/trailing
-/// whitespace is stripped out.
-pub fn insert_object_colliders(
-    commands: &mut Commands,
-    object_entity: Entity,
-    object_data: &ObjectData,
-    collider_callback: ColliderCallback,
-) {
-    insert_colliders_from_shapes(
-        commands,
-        object_entity,
-        None,
-        object_data,
-        collider_callback,
-    );
-}
-
-pub fn insert_tile_colliders(
-    commands: &mut Commands,
-    collision_object_names: &ObjectNameFilter,
-    tile_entity: Entity,
-    grid_size: &TilemapGridSize,
-    collision: &ObjectLayerData,
-    collider_callback: ColliderCallback,
-) {
-    for object_data in collision.object_data().iter() {
-        if collision_object_names.contains(&object_data.name.trim().to_lowercase()) {
-            insert_colliders_from_shapes(
-                commands,
-                tile_entity,
-                Some(grid_size),
-                object_data,
-                collider_callback,
-            );
-        }
-    }
-}
-
 /// Insert shapes as physics colliders.
-fn insert_colliders_from_shapes(
+pub(crate) fn insert_avian_colliders_from_shapes(
     commands: &mut Commands,
     parent_entity: Entity,
     grid_size: Option<&TilemapGridSize>,

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -4,9 +4,78 @@ pub mod rapier;
 #[cfg(feature = "avian")]
 pub mod avian;
 
-pub mod prelude {
-    #[cfg(feature = "avian")]
-    pub use crate::physics::avian::*;
+#[cfg(feature = "avian")]
+use avian::insert_avian_colliders_from_shapes;
+
+#[cfg(feature = "rapier")]
+use rapier::insert_rapier_colliders_from_shapes;
+
+use bevy::prelude::*;
+use bevy_ecs_tilemap::prelude::*;
+use tiled::{ObjectData, ObjectLayerData};
+
+use crate::prelude::*;
+
+/// Load shapes from an object layer as physics colliders.
+///
+/// By default `bevy_ecs_tiled` will only process object layers
+/// named in `collision_layer_names` in `TiledMapSettings`,
+/// and tileset collision shapes named in `collision_object_names`.
+///
+/// Collision layer names are case-insensitive and leading/trailing
+/// whitespace is stripped out.
+pub fn insert_object_colliders(
+    commands: &mut Commands,
+    object_entity: Entity,
+    object_data: &ObjectData,
+    collider_callback: ColliderCallback,
+) {
     #[cfg(feature = "rapier")]
-    pub use crate::physics::rapier::*;
+    insert_rapier_colliders_from_shapes(
+        commands,
+        object_entity,
+        None,
+        object_data,
+        collider_callback,
+    );
+
+    #[cfg(feature = "avian")]
+    insert_avian_colliders_from_shapes(
+        commands,
+        object_entity,
+        None,
+        object_data,
+        collider_callback,
+    );
+}
+
+pub fn insert_tile_colliders(
+    commands: &mut Commands,
+    collision_object_names: &ObjectNameFilter,
+    tile_entity: Entity,
+    grid_size: &TilemapGridSize,
+    collision: &ObjectLayerData,
+    collider_callback: ColliderCallback,
+) {
+    for object_data in collision.object_data().iter() {
+        if collision_object_names.contains(&object_data.name.trim().to_lowercase()) {
+            #[cfg(feature = "rapier")]
+            insert_rapier_colliders_from_shapes(
+                commands,
+                tile_entity,
+                Some(grid_size),
+                object_data,
+                collider_callback,
+            );
+
+            #[cfg(feature = "avian")]
+            insert_avian_colliders_from_shapes(
+                commands,
+                tile_entity,
+                Some(grid_size),
+                object_data,
+                collider_callback,
+            );
+        }
+    }
 }

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,7 +1,12 @@
 #[cfg(feature = "rapier")]
 pub mod rapier;
 
+#[cfg(feature = "avian")]
+pub mod avian;
+
 pub mod prelude {
+    #[cfg(feature = "avian")]
+    pub use crate::physics::avian::*;
     #[cfg(feature = "rapier")]
     pub use crate::physics::rapier::*;
 }

--- a/src/physics/rapier.rs
+++ b/src/physics/rapier.rs
@@ -1,56 +1,12 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
 use bevy_rapier2d::prelude::*;
-use tiled::{ObjectData, ObjectLayerData};
+use tiled::ObjectData;
 
 use crate::prelude::*;
 
-/// Load shapes from an object layer as physics colliders.
-///
-/// By default `bevy_ecs_tiled` will only process object layers
-/// named in `collision_layer_names` in `TiledMapSettings`,
-/// and tileset collision shapes named in `collision_object_names`.
-///
-/// Collision layer names are case-insensitive and leading/trailing
-/// whitespace is stripped out.
-pub fn insert_object_colliders(
-    commands: &mut Commands,
-    object_entity: Entity,
-    object_data: &ObjectData,
-    collider_callback: ColliderCallback,
-) {
-    insert_colliders_from_shapes(
-        commands,
-        object_entity,
-        None,
-        object_data,
-        collider_callback,
-    );
-}
-
-pub fn insert_tile_colliders(
-    commands: &mut Commands,
-    collision_object_names: &ObjectNameFilter,
-    tile_entity: Entity,
-    grid_size: &TilemapGridSize,
-    collision: &ObjectLayerData,
-    collider_callback: ColliderCallback,
-) {
-    for object_data in collision.object_data().iter() {
-        if collision_object_names.contains(&object_data.name.trim().to_lowercase()) {
-            insert_colliders_from_shapes(
-                commands,
-                tile_entity,
-                Some(grid_size),
-                object_data,
-                collider_callback,
-            );
-        }
-    }
-}
-
 /// Insert shapes as physics colliders.
-fn insert_colliders_from_shapes(
+pub(crate) fn insert_rapier_colliders_from_shapes(
     commands: &mut Commands,
     parent_entity: Entity,
     grid_size: Option<&TilemapGridSize>,

--- a/src/properties/events.rs
+++ b/src/properties/events.rs
@@ -2,7 +2,9 @@ use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
 use tiled::{ObjectData, TileData};
 
-#[cfg(any(feature = "rapier", feature = "avian"))]
+#[cfg(feature = "physics")]
+use crate::physics::{insert_object_colliders, insert_tile_colliders};
+#[cfg(feature = "physics")]
 use crate::prelude::*;
 
 #[derive(Event, Clone, Debug)]
@@ -32,7 +34,7 @@ impl TiledObjectCreated {
     }
 }
 
-#[cfg(any(feature = "rapier", feature = "avian"))]
+#[cfg(feature = "physics")]
 impl TiledCustomTileCreated {
     pub fn spawn_collider(
         &self,

--- a/src/properties/events.rs
+++ b/src/properties/events.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
 use tiled::{ObjectData, TileData};
 
-#[cfg(feature = "rapier")]
+#[cfg(any(feature = "rapier", feature = "avian"))]
 use crate::prelude::*;
 
 #[derive(Event, Clone, Debug)]
@@ -20,13 +20,9 @@ pub struct TiledCustomTileCreated {
     pub grid_size: TilemapGridSize,
 }
 
-#[cfg(feature = "rapier")]
+#[cfg(any(feature = "rapier", feature = "avian"))]
 impl TiledObjectCreated {
-    pub fn spawn_rapier_collider(
-        &self,
-        mut commands: Commands,
-        collider_callback: ColliderCallback,
-    ) {
+    pub fn spawn_collider(&self, mut commands: Commands, collider_callback: ColliderCallback) {
         insert_object_colliders(
             &mut commands,
             self.entity,
@@ -36,9 +32,9 @@ impl TiledObjectCreated {
     }
 }
 
-#[cfg(feature = "rapier")]
+#[cfg(any(feature = "rapier", feature = "avian"))]
 impl TiledCustomTileCreated {
-    pub fn spawn_rapier_collider(
+    pub fn spawn_collider(
         &self,
         mut commands: Commands,
         collision_object_names: ObjectNames,


### PR DESCRIPTION
Close #14 

This PR adds `physics/avian.rs` as an alternative to rapier. Avian2D was added as another optional feature and all the `#[cfg(feature = "rapier")]` were either updated to `#[cfg(any(feature = "rapier", feature = "avian"))]` or the avian conditional was added right after. 
All the rapier examples were replicated with the avian version as well.

In the properties/event.rs the function `spawn_rapier_collider` was generalized to `spawn_collider` since now it can either be rapier or avian.