### PR TITLE
Add SpawnTiledMap command to spawn map entities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod components;
 pub mod loader;
 pub mod names;
+pub mod spawner;
 
 #[cfg(feature = "physics")]
 pub mod physics;

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,7 +1,7 @@
 use bevy::utils::HashSet;
 
 /// A filter to specify names of Tiled objects.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum ObjectNames {
     #[default]
     All,

--- a/src/properties/events.rs
+++ b/src/properties/events.rs
@@ -22,7 +22,7 @@ pub struct TiledCustomTileCreated {
     pub grid_size: TilemapGridSize,
 }
 
-#[cfg(any(feature = "rapier", feature = "avian"))]
+#[cfg(feature = "physics")]
 impl TiledObjectCreated {
     pub fn spawn_collider(&self, mut commands: Commands, collider_callback: ColliderCallback) {
         insert_object_colliders(

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -1,0 +1,54 @@
+use bevy::{
+    ecs::{system::RunSystemOnce, world::Command},
+    prelude::*,
+};
+use bevy_ecs_tilemap::prelude::*;
+
+use crate::{
+    loader::{load_map_by_asset_id, TiledMap},
+    prelude::*,
+};
+
+pub struct SpawnTiledMap {
+    pub bundle: TiledMapBundle,
+}
+
+impl Command for SpawnTiledMap {
+    fn apply(self, world: &mut World) {
+        let map_handle = self.bundle.tiled_map.clone_weak();
+        world.run_system_once_with(self, spawn_tiled_map);
+        world.run_system_once_with(map_handle.id(), finalize_tiled_map)
+    }
+}
+
+fn spawn_tiled_map(spawn_tiled_map: In<SpawnTiledMap>, mut commands: Commands) {
+    commands.spawn(spawn_tiled_map.0.bundle);
+}
+
+fn finalize_tiled_map(
+    id: In<AssetId<TiledMap>>,
+    mut commands: Commands,
+    mut maps: ResMut<Assets<TiledMap>>,
+    tile_storage_query: Query<(Entity, &TileStorage)>,
+    mut map_query: Query<(
+        Entity,
+        &Handle<TiledMap>,
+        &mut TiledLayersStorage,
+        &TilemapRenderSettings,
+        &TiledMapSettings,
+    )>,
+    #[cfg(feature = "user_properties")] objects_registry: NonSend<TiledObjectRegistry>,
+    #[cfg(feature = "user_properties")] custom_tiles_registry: NonSend<TiledCustomTileRegistry>,
+) {
+    load_map_by_asset_id(
+        &mut commands,
+        &mut maps,
+        &tile_storage_query,
+        &mut map_query,
+        &id,
+        #[cfg(feature = "user_properties")]
+        &objects_registry,
+        #[cfg(feature = "user_properties")]
+        &custom_tiles_registry,
+    )
+}


### PR DESCRIPTION
Close #23 

This PR adds a new way to spawn map entities. It introduces the `spawner.rs` file with the SpawnTiledMap command which runs the code to spawn and fill a map entity. The command first spawns the map with the TIledMapBundle with a system, then runs another system to "finalize" the map which invokes `load_map_by_asset_id` exactly like the code for the `Added` asset event. The spawning code in the `Added` asset event is removed.

This allows users to load maps at different moments from the actual map spawning. For example when using `bevy_asset_loader` an user can load any map with that library in some particular state and then later use the map handle to spawn maps.

The new way to spawn maps now is:

```rust
commands.add(SpawnTiledMap {
    bundle: TiledMapBundle {
        ...
    }
}
```
