### PR TITLE
Do not rely upon `AssetEvent::added()` to actually spawn a map 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [unreleased]
 
+### Bugfixes
+
+- Do not rely upon `AssetEvent::added()` to actually spawn a map (#23)
+  Instead, query all maps that have a `Changed<Handle<TiledMap>>` or are explictelly marked for reload.
+  This allows to delay actual map spawn from asset loading (hence allowing to pre-load maps).
+
 ## v0.3.6
 
 ### Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,6 @@ required-features = ["user_properties", "avian"]
 
 [[example]]
 name = "isometric_map"
+
+[[example]]
+name = "delayed_spawn"

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,3 +28,4 @@ In most of the examples, you can use the following action keys:
 | `infinite_avian` | `avian` | This example shows an infinite orthogonal map with an external tileset and Avian2D physics. |
 | `controller_avian` | `avian` | This example shows a simple player-controlled object using Avian2D physics. You can move the object using arrow keys. |
 | `user_properties_avian` | `user_properties`, `avian` | This example shows how to map custom tiles / objects properties from Tiled to Bevy Components and manually spawn Avian colliders from them. |
+| `delayed_spawn` | None | This example will delay map spawn from asset loading to demonstrate both are decoupled. |

--- a/examples/delayed_spawn.rs
+++ b/examples/delayed_spawn.rs
@@ -1,0 +1,49 @@
+//! This example will delay map spawn from asset loading to demonstrate both are decoupled.
+
+use std::time::*;
+
+use bevy::prelude::*;
+use bevy_ecs_tiled::prelude::*;
+use bevy_ecs_tilemap::prelude::*;
+
+mod helper;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TilemapPlugin)
+        .add_plugins(TiledMapPlugin)
+        .add_plugins(helper::HelperPlugin)
+        .add_systems(Startup, startup)
+        .add_systems(Update, spawn_map)
+        .run();
+}
+
+#[derive(Resource)]
+struct MapSpawner {
+    map_handle: Handle<TiledMap>,
+    timer: Timer,
+}
+
+const DELAY_VALUE_S: u64 = 5;
+
+fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+
+    info!("Loading asset, will spawn a map in {}s ...", DELAY_VALUE_S);
+    commands.insert_resource(MapSpawner {
+        map_handle: asset_server.load("finite.tmx"),
+        timer: Timer::new(Duration::from_secs(DELAY_VALUE_S), TimerMode::Once),
+    });
+}
+
+fn spawn_map(mut commands: Commands, mut spawner: ResMut<MapSpawner>, time: Res<Time>) {
+    spawner.timer.tick(time.delta());
+    if spawner.timer.just_finished() {
+        info!("Timer finished, spawn the map !");
+        commands.spawn(TiledMapBundle {
+            tiled_map: spawner.map_handle.clone(),
+            ..Default::default()
+        });
+    }
+}

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,6 +2,10 @@ use crate::prelude::*;
 use bevy::{ecs::system::EntityCommands, prelude::*, utils::HashMap};
 use bevy_ecs_tilemap::prelude::*;
 
+/// Marker component for re-spawning the whole map
+#[derive(Component)]
+pub struct RespawnTiledMap;
+
 // Stores a list of tiled layers.
 #[derive(Component, Default)]
 pub struct TiledLayersStorage {


### PR DESCRIPTION
Close #23 

Do not rely upon `AssetEvent::added()` to actually spawn a map.
Instead, query all maps that have a `Changed<Handle<TiledMap>>` or are explictelly marked for reload.