### PR TITLE
fix: Hot Reloading Issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ fn handle_map_events(
     mut commands: Commands,
     mut map_events: EventReader<AssetEvent<TiledMap>>,
     tile_storage_query: Query<(Entity, &TileStorage)>,
-    mut map_query: Query<(Entity, &Handle<TiledMap>, &mut TiledIdStorage)>,
+    mut map_query: Query<(Entity, &TiledMapHandle, &mut TiledIdStorage)>,
     layer_query: Query<(Entity, &TiledMapLayer), With<TiledMapLayer>>,
 ) {
     for event in map_events.read() {
@@ -207,7 +207,7 @@ fn handle_map_events(
             AssetEvent::Modified { id } => {
                 log::info!("Map changed: {id}");
                 for (map_entity, map_handle, _) in map_query.iter() {
-                    if map_handle.id() == *id {
+                    if map_handle.0.id() == *id {
                         commands.entity(map_entity).insert(RespawnTiledMap);
                     }
                 }
@@ -230,16 +230,16 @@ fn handle_map_events(
 fn remove_map_by_asset_id(
     commands: &mut Commands,
     tile_storage_query: &Query<(Entity, &TileStorage)>,
-    map_query: &mut Query<(Entity, &Handle<TiledMap>, &mut TiledIdStorage)>,
+    map_query: &mut Query<(Entity, &TiledMapHandle, &mut TiledIdStorage)>,
     layer_query: &Query<(Entity, &TiledMapLayer), With<TiledMapLayer>>,
     asset_id: &AssetId<TiledMap>,
 ) {
     log::info!("removing map by asset id: {}", asset_id);
     for (_, map_handle, mut tiled_id_storage) in map_query.iter_mut() {
-        log::info!("checking layer to remove: {}", map_handle.id());
+        log::info!("checking layer to remove: {}", map_handle.0.id());
 
         // Only process the map that was removed.
-        if map_handle.id() != *asset_id {
+        if map_handle.0.id() != *asset_id {
             continue;
         }
 


### PR DESCRIPTION
### Overview

While trying this awesome plugin and trying it out for the first time, I've noticed that whenever I change something in tiled, it does not hot-reload it in my game, even though I get this in my logs:
```
2024-11-24T20:42:16.878905Z  INFO bevy_ecs_tiled: Map 'maps/desert/desert.tmx' has finished loading, spawn it
2024-11-24T20:42:26.824795Z  INFO bevy_asset::server: Reloading maps\desert\desert.tmx because it has changed
...
2024-11-24T20:42:26.889222Z  INFO bevy_ecs_tiled: Map changed: AssetId<bevy_ecs_tiled::asset::TiledMap>{ index: 0, generation: 0}    
```

But nothing actually happens. Turns out that the query for the changed map, never return anything, or basically it does not match on anything.

After applying this fix, it now works and when I change something it tiled, it hot reloads it in my game.

```
...
2024-11-24T20:42:38.873064Z  INFO bevy_ecs_tiled: Map changed: AssetId<bevy_ecs_tiled::asset::TiledMap>{ index: 0, generation: 0}
2024-11-24T20:42:38.905235Z  INFO bevy_ecs_tiled: Map 'maps/desert/desert.tmx' has finished loading, spawn it

```

### Changes
This pull request includes changes to the `src/lib.rs` file to update the handling of map events and improve code readability. The most important changes involve modifying the type used for map handles and updating the corresponding method calls.

Changes to map handle type:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L202-R210): Updated the `map_query` parameter in `fn handle_map_events` to use `TiledMapHandle` instead of `Handle<TiledMap>`.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L233-R242): Updated the `map_query` parameter in `fn remove_map_by_asset_id` to use `TiledMapHandle` instead of `Handle<TiledMap>`.

Method call updates:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L202-R210): Modified the method call from `map_handle.id()` to `map_handle.0.id()` in `fn handle_map_events`.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L233-R242): Modified the method call from `map_handle.id()` to `map_handle.0.id()` in `fn remove_map_by_asset_id`.