### PR TITLE
chore: Replace dbg! call with trace! in src/asset.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [unreleased]
 
+## v0.4.2
+
+### Changed
+
+- Removed the `dbg!` macro from the codebase and replaced it with `trace!` (#54)
+
+### Documentation
+
+- Added a note about the `logging` and `tracing` features in the debugging guide (#54)
+
 ## v0.4.1
 
 ### Changed

--- a/book/src/guides/debug.md
+++ b/book/src/guides/debug.md
@@ -86,3 +86,21 @@ fn main() {
 ```
 
 And you also need to enable either the `debug-render-2d` feature on `bevy_rapier2d` crate or the `rapier_debug` feature on `bevy_ecs_tiled`
+
+## Logging
+
+Bevy uses the `tracing` crate for logging, which is very powerful in debugging and profiling, you can find more information in the [official documentation](https://docs.rs/tracing/).
+
+We recommend to enable the `trace` level in your application to get more informations about what's happening, just set the `RUST_LOG` environment variable to `trace`:
+
+```sh
+RUST_LOG=trace cargo run
+```
+
+But this will be very verbose, so you can also filter the logs to only display the informations you need:
+
+```sh
+RUST_LOG=bevy_ecs_tiled=trace cargo run
+```
+
+This will only display logs from the `bevy_ecs_tiled` crate in `trace` level.

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -50,7 +50,7 @@ impl<'a, 'b> BytesResourceReader<'a, 'b> {
     }
 }
 
-impl<'a, 'b> tiled::ResourceReader for BytesResourceReader<'a, 'b> {
+impl<'a> tiled::ResourceReader for BytesResourceReader<'a, '_> {
     type Resource = Box<dyn Read + 'a>;
     type Error = IoError;
 

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,3 +1,5 @@
+//! This module contains all [Asset]s definition.
+
 use std::io::{Cursor, Error as IoError, ErrorKind, Read};
 #[cfg(feature = "user_properties")]
 use std::ops::Deref;

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,5 +1,3 @@
-//! This module contains all [Asset]s definition.
-
 use std::io::{Cursor, Error as IoError, ErrorKind, Read};
 #[cfg(feature = "user_properties")]
 use std::ops::Deref;
@@ -164,7 +162,7 @@ impl AssetLoader for TiledLoader {
             DeserializedMapProperties::load(&map, self.registry.read().deref(), load_context);
 
         #[cfg(feature = "user_properties")]
-        dbg!(&properties);
+        trace!(?properties, "user properties");
 
         let asset_map = TiledMap {
             map,


### PR DESCRIPTION
Fixes #53

* Replace the `dbg!` call with `trace!(?properties, "user properties")` to log the properties at the trace level.
