### PR TITLE
Use polyline for tiled polygons to account for convex shapes

### DIFF
--- a/src/physics/avian.rs
+++ b/src/physics/avian.rs
@@ -4,11 +4,11 @@
 
 use avian2d::{math::Vector, prelude::*};
 use bevy::prelude::*;
-use tiled::Map;
+use tiled::{Map, ObjectShape};
 
 use crate::prelude::*;
 
-/// The actual Avian physics backend to use when instanciating the physics plugin.
+/// The actual Avian physics backend to use when instantiating the physics plugin.
 ///
 /// Example:
 /// ```rust,no_run
@@ -21,7 +21,7 @@ use crate::prelude::*;
 #[derive(Default)]
 pub struct TiledPhysicsAvianBackend;
 
-impl super::TiledPhysicsBackend for TiledPhysicsAvianBackend {
+impl TiledPhysicsBackend for TiledPhysicsAvianBackend {
     fn spawn_collider(
         &self,
         commands: &mut Commands,
@@ -51,49 +51,56 @@ impl super::TiledPhysicsBackend for TiledPhysicsAvianBackend {
             } => object.as_deref(),
         })?;
 
-        let (pos, collider) = match &object_data.shape {
-            tiled::ObjectShape::Rect { width, height } => {
-                // The origin is the top-left corner of the rectangle when not rotated.
-                let shape = Collider::rectangle(*width, *height);
-                let pos = Vector::new(width / 2., -height / 2.);
-                (pos, shape)
-            }
-            tiled::ObjectShape::Ellipse { width, height } => {
-                let shape = Collider::ellipse(width / 2., height / 2.);
-                let pos = Vector::new(width / 2., -height / 2.);
-                (pos, shape)
-            }
-            tiled::ObjectShape::Polyline { points } => {
-                let shape = Collider::polyline(
-                    points.iter().map(|(x, y)| Vector::new(*x, -*y)).collect(),
-                    None,
-                );
-                (Vector::ZERO, shape)
-            }
-            tiled::ObjectShape::Polygon { points } => {
-                let shape = match Collider::convex_hull(
-                    points
-                        .iter()
-                        .map(|(x, y)| Vector::new(*x, -*y))
-                        .collect::<Vec<Vector>>(),
-                ) {
-                    Some(x) => x,
-                    None => {
-                        return None;
-                    }
-                };
+        let (pos, collider) = get_position_and_collider(&object_data.shape)?;
 
-                (Vector::ZERO, shape)
-            }
-            _ => {
-                return None;
-            }
-        };
         Some(TiledColliderSpawnInfos {
             name: format!("Avian[{}]", object_data.name),
             entity: commands.spawn(collider).id(),
             position: pos,
             rotation: -object_data.rotation,
         })
+    }
+}
+
+fn get_position_and_collider(shape: &ObjectShape) -> Option<(Vector, Collider)> {
+    match shape {
+        ObjectShape::Rect { width, height } => {
+            // The origin is the top-left corner of the rectangle when not rotated.
+            let shape = Collider::rectangle(*width, *height);
+            let pos = Vector::new(width / 2., -height / 2.);
+            Some((pos, shape))
+        }
+        ObjectShape::Ellipse { width, height } => {
+            let shape = Collider::ellipse(width / 2., height / 2.);
+            let pos = Vector::new(width / 2., -height / 2.);
+            Some((pos, shape))
+        }
+        ObjectShape::Polyline { points } => {
+            let shape = Collider::polyline(
+                points.iter().map(|(x, y)| Vector::new(*x, -*y)).collect(),
+                None,
+            );
+            Some((Vector::ZERO, shape))
+        }
+        ObjectShape::Polygon { points } => {
+            if points.len() < 3 {
+                return None;
+            }
+
+            let points = points
+                .iter()
+                .map(|(x, y)| Vector::new(*x, -*y))
+                .collect::<Vec<_>>();
+
+            let indices = (0..points.len() as u32 - 1)
+                .map(|i| [i, i + 1])
+                .chain([[points.len() as u32 - 1, 0]])
+                .collect();
+
+            let shape = Collider::polyline(points, Some(indices));
+
+            Some((Vector::ZERO, shape))
+        }
+        _ => None,
     }
 }


### PR DESCRIPTION
Fixes #65, more context on the issue.

Tiled polygons seem to require at least 3 points to create as far as I can tell, since 2 points would end up being a polyline.