### PR TITLE
Try to merge all colliders from a tiles layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@
 ### Features
 
 - Add Tiled .world file support (#55)
+- Aggregate tiles colliders together: likely to reduce the overall number of colliders which improves performances (#68)
 
 ### Changed
 
 - `TiledPhysicsBackend` now requires to implement the `Clone` trait
 - Switched some map logs from `info!()` to `debug!()`
+- `TiledPhysicsBackend::spawn_collider()` is now expected to spawn several colliders in on call. To reflect that, now it returns a `Vec<TiledColliderSpawnInfos>` instead of an `Option<TiledColliderSpawnInfos>`
+- Remove the `TiledColliderSourceType::Tile` which is superseded by `TiledColliderSourceType::TilesLayer`
+- Remove the capacity to filter out tiles colliders using the collider object name
 
 ## v0.5.1
 

--- a/book/src/guides/physics.md
+++ b/book/src/guides/physics.md
@@ -66,11 +66,10 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         TiledMapHandle(asset_server.load("finite.tmx")),
         // With this configuration, we will restrict the spawn of collider
-        // for objects named 'collision' attached to a tile.
-        // No collider for objects attached to objects layer.
+        // for tiles in a layer named 'collision' and prevent spawning colliders for Tiled objects.
         TiledPhysicsSettings::<TiledPhysicsAvianBackend> {
             objects_layer_filter: ObjectNames::None,
-            tiles_objects_filter: ObjectNames::Names(vec!["collision".to_string()]),
+            tiles_layer_filter: ObjectNames::Names(vec!["collision".to_string()]),
             ..default()
         },
     ));
@@ -89,3 +88,11 @@ You can even use one the provided backend, but if their implementation have some
 Finally, whatever the backend you are using, a dedicated [`TiledColliderCreated`](https://docs.rs/bevy_ecs_tiled/latest/bevy_ecs_tiled/physics/collider/struct.TiledColliderCreated.html) event will be fired after a collider is spawned.
 Note that you will have one event per spawned collider.
 These events can be used for instance to add a missing component to the collider (or anything you want).
+
+## Special considerations
+
+For Tiled objects (ie. objects attached to an object layer), we will spawn one collider per object.
+
+For objects attached to tiles, we will try to merge all colliders from a given layer together so from a physics point of view, we actually have a single collider.
+The idea is to improve performances by reducing the number of entities we spawn.
+However, keep in mind that if you use complex geometric forms for your collisions, we won't be able to merge these colliders and you will end up with a lot of entities which can impact performances.

--- a/examples/physics_avian_controller.rs
+++ b/examples/physics_avian_controller.rs
@@ -49,11 +49,11 @@ impl TiledPhysicsBackend for MyCustomAvianPhysicsBackend {
         commands: &mut Commands,
         map: &Map,
         collider_source: &TiledColliderSource,
-    ) -> Option<TiledColliderSpawnInfos> {
-        let collider = self.0.spawn_collider(commands, map, collider_source);
-        if let Some(c) = &collider {
+    ) -> Vec<TiledColliderSpawnInfos> {
+        let colliders = self.0.spawn_collider(commands, map, collider_source);
+        for c in &colliders {
             commands.entity(c.entity).insert(RigidBody::Static);
         }
-        collider
+        colliders
     }
 }

--- a/examples/physics_avian_settings.rs
+++ b/examples/physics_avian_settings.rs
@@ -58,22 +58,6 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     mgr.add_map(helper::assets::MapInfos::new(
         &asset_server,
         "finite.tmx",
-        "A finite orthogonal map with only tiles colliders named 'collision'",
-        |c| {
-            c.insert(TiledMapSettings {
-                layer_positioning: LayerPositioning::Centered,
-                ..default()
-            });
-            c.insert(TiledPhysicsSettings::<TiledPhysicsAvianBackend> {
-                objects_layer_filter: ObjectNames::None,
-                tiles_objects_filter: ObjectNames::Names(vec!["collision".to_string()]),
-                ..default()
-            });
-        },
-    ));
-    mgr.add_map(helper::assets::MapInfos::new(
-        &asset_server,
-        "finite.tmx",
         "A finite orthogonal map with only object colliders",
         |c| {
             c.insert(TiledMapSettings {
@@ -82,7 +66,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             });
             c.insert(TiledPhysicsSettings::<TiledPhysicsAvianBackend> {
                 objects_layer_filter: ObjectNames::All,
-                tiles_objects_filter: ObjectNames::None,
+                tiles_layer_filter: ObjectNames::None,
                 ..default()
             });
         },

--- a/examples/physics_rapier_controller.rs
+++ b/examples/physics_rapier_controller.rs
@@ -48,13 +48,13 @@ impl TiledPhysicsBackend for MyCustomRapierPhysicsBackend {
         commands: &mut Commands,
         map: &Map,
         collider_source: &TiledColliderSource,
-    ) -> Option<TiledColliderSpawnInfos> {
-        let collider = self.0.spawn_collider(commands, map, collider_source);
-        if let Some(c) = &collider {
+    ) -> Vec<TiledColliderSpawnInfos> {
+        let colliders = self.0.spawn_collider(commands, map, collider_source);
+        for c in &colliders {
             commands
                 .entity(c.entity)
                 .insert(RigidBody::KinematicPositionBased);
         }
-        collider
+        colliders
     }
 }

--- a/examples/physics_rapier_settings.rs
+++ b/examples/physics_rapier_settings.rs
@@ -58,22 +58,6 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     mgr.add_map(helper::assets::MapInfos::new(
         &asset_server,
         "finite.tmx",
-        "A finite orthogonal map with only tiles colliders named 'collision'",
-        |c| {
-            c.insert(TiledMapSettings {
-                layer_positioning: LayerPositioning::Centered,
-                ..default()
-            });
-            c.insert(TiledPhysicsSettings::<TiledPhysicsRapierBackend> {
-                objects_layer_filter: ObjectNames::None,
-                tiles_objects_filter: ObjectNames::Names(vec!["collision".to_string()]),
-                ..default()
-            });
-        },
-    ));
-    mgr.add_map(helper::assets::MapInfos::new(
-        &asset_server,
-        "finite.tmx",
         "A finite orthogonal map with only object colliders",
         |c| {
             c.insert(TiledMapSettings {
@@ -82,7 +66,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             });
             c.insert(TiledPhysicsSettings::<TiledPhysicsRapierBackend> {
                 objects_layer_filter: ObjectNames::All,
-                tiles_objects_filter: ObjectNames::None,
+                tiles_layer_filter: ObjectNames::None,
                 ..default()
             });
         },

--- a/src/map/events.rs
+++ b/src/map/events.rs
@@ -99,7 +99,7 @@ impl<'a> TiledObjectCreated {
             .unwrap()
     }
 
-    /// Retrieve object world position (origin = top left).
+    /// Retrieve object world position (origin = top left) relative to its parent layer.
     pub fn world_position(&self, map_asset: &'a Res<Assets<TiledMap>>) -> Vec2 {
         let map = self.map(map_asset);
         let object_data = self.object(map_asset);
@@ -176,7 +176,7 @@ impl<'a> TiledSpecialTileCreated {
             .unwrap()
     }
 
-    /// Retrieve tile world position (origin = tile center).
+    /// Retrieve tile world position (origin = tile center) relative to its parent layer.
     pub fn world_position(&self, map_asset: &'a Res<Assets<TiledMap>>) -> Vec2 {
         let map = self.map(map_asset);
         self.tilemap_index

--- a/src/map/loader.rs
+++ b/src/map/loader.rs
@@ -698,8 +698,6 @@ fn handle_special_tile(
     entity_map: &mut HashMap<(String, TileId), Vec<Entity>>,
     event_list: &mut Vec<TiledSpecialTileCreated>,
 ) {
-    let mut is_special_tile = false;
-
     // Handle animated tiles
     if let Some(animated_tile) = get_animated_tile(tile) {
         commands.entity(tile_infos.tile).insert(animated_tile);
@@ -714,15 +712,6 @@ fn handle_special_tile(
                 entities.push(tile_infos.tile);
             })
             .or_insert(vec![tile_infos.tile]);
-        is_special_tile = true;
-    }
-
-    // Handle tiles with collision
-    if let Some(_collision) = tile.collision.as_ref() {
-        is_special_tile = true;
-    }
-
-    if is_special_tile {
         event_list.push(tile_infos);
     }
 }

--- a/src/map/loader.rs
+++ b/src/map/loader.rs
@@ -271,7 +271,7 @@ fn load_tiles_layer(
                     event_list,
                 );
                 _map_size = new_map_size;
-                // log::info!("Infinite layer origin: {:?}", origin);
+                debug!("Infinite layer origin: {:?}", origin);
                 _offset_x += origin.0 * grid_size.x;
                 _offset_y -= origin.1 * grid_size.y;
                 storage
@@ -417,7 +417,7 @@ fn load_infinite_tiles_layer(
             (acc.0.max(pos.0), acc.1.max(pos.1))
         });
 
-    log::info!(
+    debug!(
         "(infinite map) topleft: ({}, {}), bottomright: ({}, {})",
         topleft_x,
         topleft_y,
@@ -433,7 +433,7 @@ fn load_infinite_tiles_layer(
         x: (bottomright_x - topleft_x + 1) as u32 * ChunkData::WIDTH,
         y: (bottomright_y - topleft_y + 1) as u32 * ChunkData::HEIGHT,
     };
-    log::info!("(infinite map) size: {:?}", map_size);
+    debug!("(infinite map) size: {:?}", map_size);
     let origin = (
         topleft_x as f32 * ChunkData::WIDTH as f32,
         ((topleft_y as f32 / 2.) * ChunkData::HEIGHT as f32) + 1.,

--- a/src/map/loader.rs
+++ b/src/map/loader.rs
@@ -419,10 +419,7 @@ fn load_infinite_tiles_layer(
 
     debug!(
         "(infinite map) topleft: ({}, {}), bottomright: ({}, {})",
-        topleft_x,
-        topleft_y,
-        bottomright_x,
-        bottomright_y
+        topleft_x, topleft_y, bottomright_x, bottomright_y
     );
 
     // TODO: Provide a way to surface the origin point (the point that was 0,0 in Tiled)

--- a/src/physics/avian.rs
+++ b/src/physics/avian.rs
@@ -2,7 +2,13 @@
 //!
 //! Only available when the `avian` feature is enabled.
 
-use avian2d::{math::Vector, prelude::*};
+use avian2d::{
+    parry::{
+        math::{Isometry, Real},
+        shape::SharedShape,
+    },
+    prelude::*,
+};
 use bevy::prelude::*;
 use tiled::{Map, ObjectShape};
 
@@ -27,79 +33,121 @@ impl TiledPhysicsBackend for TiledPhysicsAvianBackend {
         commands: &mut Commands,
         map: &Map,
         collider_source: &TiledColliderSource,
-    ) -> Option<TiledColliderSpawnInfos> {
-        // TODO: use this function once I figure out how to prevent cloning ObjectData
-        // let object_data = collider_source.object_data(map)?;
-
-        let tile = collider_source.tile(map);
-        let object = collider_source.object(map);
-
-        let object_data = (match collider_source.ty {
-            TiledColliderSourceType::Tile {
-                layer_id: _,
-                x: _,
-                y: _,
-                object_id,
-            } => tile
-                .as_ref()
-                .and_then(|tile| tile.collision.as_ref())
-                .map(|collision| collision.object_data())
-                .and_then(|objects| objects.get(object_id)),
+    ) -> Vec<TiledColliderSpawnInfos> {
+        match collider_source.ty {
             TiledColliderSourceType::Object {
                 layer_id: _,
                 object_id: _,
-            } => object.as_deref(),
-        })?;
-
-        let (pos, collider) = get_position_and_collider(&object_data.shape)?;
-
-        Some(TiledColliderSpawnInfos {
-            name: format!("Avian[{}]", object_data.name),
-            entity: commands.spawn(collider).id(),
-            position: pos,
-            rotation: -object_data.rotation,
-        })
+            } => {
+                let Some(object) = collider_source.object(map) else {
+                    return vec![];
+                };
+                let Some((pos, shared_shape, _)) = get_position_and_shape(&object.shape) else {
+                    return vec![];
+                };
+                let collider: Collider = shared_shape.into();
+                vec![TiledColliderSpawnInfos {
+                    name: format!("Avian[Object={}]", object.name),
+                    entity: commands.spawn(collider).id(),
+                    position: pos,
+                    rotation: -object.rotation,
+                }]
+            }
+            TiledColliderSourceType::TilesLayer { layer_id: _ } => {
+                let mut composables = vec![];
+                let mut spawn_infos = vec![];
+                for (tile_position, tile) in collider_source.tiles_from_layer(map) {
+                    if let Some(collision) = &tile.collision {
+                        for object in collision.object_data() {
+                            let object_position = Vec2 {
+                                x: object.x - map.tile_width as f32 / 2.,
+                                y: (map.tile_height as f32 - object.y)
+                                    - map.tile_height as f32 / 2.,
+                            };
+                            if let Some((mut position, shared_shape, is_composable)) =
+                                get_position_and_shape(&object.shape)
+                            {
+                                position += tile_position + object_position;
+                                position += Vec2 {
+                                    x: (map.tile_width as f32) / 2.,
+                                    y: (map.tile_height as f32) / 2.,
+                                };
+                                if is_composable {
+                                    composables.push((
+                                        Isometry::<Real>::new(
+                                            position.into(),
+                                            f32::to_radians(-object.rotation),
+                                        ),
+                                        shared_shape,
+                                    ));
+                                } else {
+                                    let collider: Collider = shared_shape.into();
+                                    spawn_infos.push(TiledColliderSpawnInfos {
+                                        name: "Avian[ComplexTile]".to_string(),
+                                        entity: commands.spawn(collider).id(),
+                                        position,
+                                        rotation: -object.rotation,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                if !composables.is_empty() {
+                    let collider: Collider = SharedShape::compound(composables).into();
+                    spawn_infos.push(TiledColliderSpawnInfos {
+                        name: "Avian[ComposedTile]".to_string(),
+                        entity: commands.spawn(collider).id(),
+                        position: Vec2::ZERO,
+                        rotation: 0.,
+                    });
+                }
+                spawn_infos
+            }
+        }
     }
 }
 
-fn get_position_and_collider(shape: &ObjectShape) -> Option<(Vector, Collider)> {
+fn get_position_and_shape(shape: &ObjectShape) -> Option<(Vec2, SharedShape, bool)> {
     match shape {
         ObjectShape::Rect { width, height } => {
-            // The origin is the top-left corner of the rectangle when not rotated.
-            let shape = Collider::rectangle(*width, *height);
-            let pos = Vector::new(width / 2., -height / 2.);
-            Some((pos, shape))
+            let shape = SharedShape::cuboid(width / 2., height / 2.);
+            let pos = Vec2::new(width / 2., -height / 2.);
+            Some((pos, shape, true))
         }
         ObjectShape::Ellipse { width, height } => {
-            let shape = Collider::ellipse(width / 2., height / 2.);
-            let pos = Vector::new(width / 2., -height / 2.);
-            Some((pos, shape))
+            let shape = SharedShape::new(EllipseColliderShape(Ellipse::new(
+                width / 2.0,
+                height / 2.0,
+            )));
+            let pos = Vec2::new(width / 2., -height / 2.);
+            Some((pos, shape, true))
         }
         ObjectShape::Polyline { points } => {
-            let shape = Collider::polyline(
-                points.iter().map(|(x, y)| Vector::new(*x, -*y)).collect(),
-                None,
-            );
-            Some((Vector::ZERO, shape))
+            let vertices = points
+                .iter()
+                .map(|(x, y)| Vec2::new(*x, -*y))
+                .map(|v| v.into())
+                .collect();
+            let shape = SharedShape::polyline(vertices, None);
+            Some((Vec2::ZERO, shape, false))
         }
         ObjectShape::Polygon { points } => {
             if points.len() < 3 {
                 return None;
             }
 
-            let points = points
+            let vertices = points
                 .iter()
-                .map(|(x, y)| Vector::new(*x, -*y))
-                .collect::<Vec<_>>();
-
+                .map(|(x, y)| Vec2::new(*x, -*y))
+                .map(|v| v.into())
+                .collect();
             let indices = (0..points.len() as u32 - 1)
                 .map(|i| [i, i + 1])
                 .chain([[points.len() as u32 - 1, 0]])
                 .collect();
-
-            let shape = Collider::polyline(points, Some(indices));
-
-            Some((Vector::ZERO, shape))
+            let shape = SharedShape::polyline(vertices, Some(indices));
+            Some((Vec2::ZERO, shape, false))
         }
         _ => None,
     }

--- a/src/physics/collider.rs
+++ b/src/physics/collider.rs
@@ -1,7 +1,8 @@
 //! Module that handles colliders
 use crate::prelude::*;
 use bevy::prelude::*;
-use tiled::{Layer, Map, Object, Tile};
+use bevy_ecs_tilemap::{map::TilemapSize, tiles::TilePos};
+use tiled::{ChunkData, Layer, Map, Object, Tile, TileLayer};
 
 /// Marker component for colliders
 #[derive(Component)]
@@ -11,6 +12,10 @@ pub struct TiledColliderMarker;
 /// Describe the type of the [TiledColliderSource].
 #[derive(Copy, Clone, Debug)]
 pub enum TiledColliderSourceType {
+    TilesLayer {
+        /// ID of the layer
+        layer_id: usize,
+    },
     /// Collider is created by an [Object]
     Object {
         /// ID of the layer containing the [Object].
@@ -18,25 +23,10 @@ pub enum TiledColliderSourceType {
         /// ID of the [Object].
         object_id: usize,
     },
-    /// Collider is created by a collider object on a [Tile]
-    ///
-    /// Note that a [Tile] can have several collider object.
-    Tile {
-        /// ID of the layer containing the [Tile].
-        layer_id: usize,
-        /// X position of the [Tile] in Tiled referential.
-        x: i32,
-        /// Y position of the [Tile] in Tiled referential.
-        y: i32,
-        /// ID of the collider [Object] for this [Tile].
-        ///
-        /// ID is unique for a given [Tile].
-        object_id: usize,
-    },
 }
 
 impl TiledColliderSourceType {
-    /// Create a new [TiledColliderSourceType] for an [Object].
+    /// Create a new [TiledColliderSourceType::Object].
     pub fn new_object(layer_id: usize, object_id: usize) -> Self {
         Self::Object {
             layer_id,
@@ -44,14 +34,9 @@ impl TiledColliderSourceType {
         }
     }
 
-    /// Create a new [TiledColliderSourceType] for a [Tile].
-    pub fn new_tile(layer_id: usize, x: i32, y: i32, object_id: usize) -> Self {
-        Self::Tile {
-            layer_id,
-            x,
-            y,
-            object_id,
-        }
+    /// Create a new [TiledColliderSourceType::TilesLayer].
+    pub fn new_tiles_layer(layer_id: usize) -> Self {
+        Self::TilesLayer { layer_id }
     }
 }
 
@@ -68,33 +53,11 @@ impl<'a> TiledColliderSource {
     /// Get the underlying [Layer] of a [TiledColliderSource].
     pub fn layer(&self, map: &'a Map) -> Option<Layer<'a>> {
         match self.ty {
-            TiledColliderSourceType::Tile {
-                layer_id,
-                x: _,
-                y: _,
-                object_id: _,
-            } => map.get_layer(layer_id),
             TiledColliderSourceType::Object {
                 layer_id,
                 object_id: _,
             } => map.get_layer(layer_id),
-        }
-    }
-
-    /// Get the underlying [Tile] of a [TiledColliderSource].
-    pub fn tile(&self, map: &'a Map) -> Option<Tile<'a>> {
-        match self.ty {
-            TiledColliderSourceType::Tile {
-                layer_id,
-                x,
-                y,
-                object_id: _,
-            } => map
-                .get_layer(layer_id)
-                .and_then(|layer| layer.as_tile_layer())
-                .and_then(|tile_layer| tile_layer.get_tile(x, y))
-                .and_then(|layer_tile| layer_tile.get_tile()),
-            _ => None,
+            TiledColliderSourceType::TilesLayer { layer_id } => map.get_layer(layer_id),
         }
     }
 
@@ -112,27 +75,90 @@ impl<'a> TiledColliderSource {
         }
     }
 
-    // TODO: we should use this function when I figure out how to prevent cloning ObjectData
-    // pub fn object_data(&self, map: &'a Map) -> Option<ObjectData> {
-    //     match self {
-    //         TiledColliderSourceType::Tile {
-    //             layer_id: _,
-    //             x: _,
-    //             y: _,
-    //             object_id,
-    //         } => self
-    //             .tile(map)
-    //             .as_ref()
-    //             .and_then(|tile| tile.collision.as_ref())
-    //             .map(|collision| collision.object_data())
-    //             .and_then(|objects| objects.get(*object_id))
-    //             .cloned(),
-    //         TiledColliderSourceType::Object {
-    //             layer_id: _,
-    //             object_id: _,
-    //         } => self.object(map).map(|object| object.deref().clone()),
-    //     }
-    // }
+    /// Get a vector containing tiles in this layer as well as their relative position
+    /// to their parent layer.
+    pub fn tiles_from_layer(&self, map: &'a Map) -> Vec<(Vec2, Tile<'a>)> {
+        match self.ty {
+            TiledColliderSourceType::TilesLayer { layer_id } => map
+                .get_layer(layer_id)
+                .and_then(|layer| layer.as_tile_layer())
+                .map(|layer| {
+                    let mut out = vec![];
+                    match layer {
+                        TileLayer::Finite(layer) => {
+                            for x in 0..layer.width() {
+                                for y in 0..layer.height() {
+                                    let mapped_x = x as i32;
+                                    let mapped_y = (layer.height() - 1 - y) as i32;
+                                    if let Some(tile) = layer.get_tile(mapped_x, mapped_y) {
+                                        if let Some(tile) = tile.get_tile() {
+                                            let tile_pos = TilePos::new(x, y).center_in_world(
+                                                &get_grid_size(map),
+                                                &get_map_type(map),
+                                            );
+                                            out.push((tile_pos, tile));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        TileLayer::Infinite(layer) => {
+                            let grid_size = get_grid_size(map);
+                            let map_type = get_map_type(map);
+                            let (topleft_x, topleft_y) =
+                                layer.chunks().fold((999999, 999999), |acc, (pos, _)| {
+                                    (acc.0.min(pos.0), acc.1.min(pos.1))
+                                });
+                            let (bottomright_x, bottomright_y) = layer
+                                .chunks()
+                                .fold((topleft_x, topleft_y), |acc, (pos, _)| {
+                                    (acc.0.max(pos.0), acc.1.max(pos.1))
+                                });
+                            let map_size = TilemapSize {
+                                x: (bottomright_x - topleft_x + 1) as u32 * ChunkData::WIDTH,
+                                y: (bottomright_y - topleft_y + 1) as u32 * ChunkData::HEIGHT,
+                            };
+                            let origin = (
+                                topleft_x as f32 * ChunkData::WIDTH as f32,
+                                ((topleft_y as f32 / 2.) * ChunkData::HEIGHT as f32) + 1.,
+                            );
+                            for (chunk_pos, chunk) in layer.chunks() {
+                                let chunk_pos_mapped =
+                                    (chunk_pos.0 - topleft_x, chunk_pos.1 - topleft_y);
+                                for x in 0..ChunkData::WIDTH {
+                                    for y in 0..ChunkData::HEIGHT {
+                                        if let Some(tile) = chunk.get_tile(x as i32, y as i32) {
+                                            if let Some(tile) = tile.get_tile() {
+                                                let (tile_x, tile_y) = (
+                                                    chunk_pos_mapped.0 * ChunkData::WIDTH as i32
+                                                        + x as i32,
+                                                    chunk_pos_mapped.1 * ChunkData::HEIGHT as i32
+                                                        + y as i32,
+                                                );
+                                                let tile_pos = TilePos {
+                                                    x: tile_x as u32,
+                                                    y: map_size.y - 1 - tile_y as u32,
+                                                };
+                                                let mut tile_pos =
+                                                    tile_pos.center_in_world(&grid_size, &map_type);
+                                                tile_pos += Vec2::new(
+                                                    origin.0 * grid_size.x,
+                                                    origin.1 * grid_size.y,
+                                                );
+                                                out.push((tile_pos, tile));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    out
+                })
+                .unwrap_or_default(),
+            _ => vec![],
+        }
+    }
 }
 
 /// Spawn informations about a collider
@@ -170,11 +196,6 @@ impl<'a> TiledColliderCreated {
         self.collider_source.layer(self.map(map_asset))
     }
 
-    /// Retrieve the [Tile] associated to this [TiledColliderCreated] event.
-    pub fn tile(&self, map_asset: &'a Res<Assets<TiledMap>>) -> Option<Tile<'a>> {
-        self.collider_source.tile(self.map(map_asset))
-    }
-
     /// Retrieve the [Object] associated to this [TiledColliderCreated] event.
     pub fn object(&self, map_asset: &'a Res<Assets<TiledMap>>) -> Option<Object<'a>> {
         self.collider_source.object(self.map(map_asset))
@@ -187,30 +208,24 @@ pub(super) fn spawn_collider<T: super::TiledPhysicsBackend>(
     map_asset: &Res<Assets<TiledMap>>,
     map_handle: &Handle<TiledMap>,
     collider_source: &TiledColliderSource,
-    offset: Vec2,
 ) {
     if let Some(tiled_map) = map_asset.get(map_handle) {
-        if let Some(collider) = backend.spawn_collider(commands, &tiled_map.map, collider_source) {
-            let transform = Transform {
-                translation: Vec3::new(offset.x, offset.y, 0.),
-                rotation: Quat::from_rotation_z(f32::to_radians(collider.rotation)),
-                ..default()
-            } * Transform::from_translation(Vec3::new(
-                collider.position.x,
-                collider.position.y,
-                0.,
-            ));
+        for spawn_infos in backend.spawn_collider(commands, &tiled_map.map, collider_source) {
             commands
-                .entity(collider.entity)
+                .entity(spawn_infos.entity)
                 .insert((
                     TiledColliderMarker,
-                    transform,
-                    Name::new(format!("Collider: {}", collider.name)),
+                    Name::new(format!("Collider: {}", spawn_infos.name)),
+                    Transform {
+                        translation: Vec3::new(spawn_infos.position.x, spawn_infos.position.y, 0.),
+                        rotation: Quat::from_rotation_z(f32::to_radians(spawn_infos.rotation)),
+                        ..default()
+                    },
                 ))
                 .set_parent(collider_source.entity);
             commands.trigger(TiledColliderCreated {
                 map_handle: map_handle.clone(),
-                collider,
+                collider: spawn_infos,
                 collider_source: *collider_source,
             });
         }

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -134,7 +134,7 @@ fn collider_from_tiles_layer<T: TiledPhysicsBackend>(
         return;
     };
 
-    if ObjectNameFilter::from(&settings.objects_layer_filter).contains(&layer.name) {
+    if ObjectNameFilter::from(&settings.tiles_layer_filter).contains(&layer.name) {
         collider::spawn_collider::<T>(
             &settings.backend,
             &mut commands,

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -46,7 +46,7 @@ pub trait TiledPhysicsBackend:
         commands: &mut Commands,
         map: &Map,
         collider_source: &TiledColliderSource,
-    ) -> Option<TiledColliderSpawnInfos>;
+    ) -> Vec<TiledColliderSpawnInfos>;
 }
 
 /// Physics related settings.
@@ -67,11 +67,6 @@ pub struct TiledPhysicsSettings<T: TiledPhysicsBackend> {
     /// Colliders will be automatically added for all tiles collision objects whose layer name matches this filter.
     /// By default, we add colliders for all collision objects.
     pub tiles_layer_filter: ObjectNames,
-    /// Specify which tiles collision object to add colliders for using their name.
-    ///
-    /// Colliders will be automatically added for all tiles collision objects whose name matches this filter.
-    /// By default, we add colliders for all collision objects.
-    pub tiles_objects_filter: ObjectNames,
     /// Physics backend to use for adding colliders.
     pub backend: T,
 }
@@ -95,8 +90,8 @@ pub struct TiledPhysicsPlugin<T: TiledPhysicsBackend>(std::marker::PhantomData<T
 impl<T: TiledPhysicsBackend> Plugin for TiledPhysicsPlugin<T> {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.add_observer(default_physics_settings::<T>);
+        app.add_observer(collider_from_tiles_layer::<T>);
         app.add_observer(collider_from_object::<T>);
-        app.add_observer(collider_from_tile::<T>);
     }
 }
 
@@ -121,6 +116,35 @@ fn default_physics_settings<T: TiledPhysicsBackend>(
                     .insert(TiledPhysicsSettings::<T>::default());
             }
         }
+    }
+}
+
+fn collider_from_tiles_layer<T: TiledPhysicsBackend>(
+    trigger: Trigger<TiledLayerCreated>,
+    mut commands: Commands,
+    map_asset: Res<Assets<TiledMap>>,
+    q_settings: Query<&TiledPhysicsSettings<T>, With<TiledMapMarker>>,
+) {
+    let layer = trigger.event().layer(&map_asset);
+    if layer.as_tile_layer().is_none() {
+        return;
+    }
+
+    let Ok(settings) = q_settings.get(trigger.event().map) else {
+        return;
+    };
+
+    if ObjectNameFilter::from(&settings.objects_layer_filter).contains(&layer.name) {
+        collider::spawn_collider::<T>(
+            &settings.backend,
+            &mut commands,
+            &map_asset,
+            &trigger.event().map_handle,
+            &TiledColliderSource {
+                entity: trigger.event().layer,
+                ty: TiledColliderSourceType::new_tiles_layer(trigger.event().layer_id),
+            },
+        );
     }
 }
 
@@ -151,77 +175,6 @@ fn collider_from_object<T: TiledPhysicsBackend>(
                     trigger.event().object_id,
                 ),
             },
-            Vec2::ZERO,
         );
-    }
-}
-
-fn collider_from_tile<T: TiledPhysicsBackend>(
-    trigger: Trigger<TiledSpecialTileCreated>,
-    mut commands: Commands,
-    map_asset: Res<Assets<TiledMap>>,
-    q_settings: Query<&TiledPhysicsSettings<T>, With<TiledMapMarker>>,
-) {
-    if let Some(tile_data) = trigger.event().tile(&map_asset).get_tile() {
-        if tile_data.collision.is_none() {
-            return;
-        }
-    };
-
-    let Ok(settings) = q_settings.get(trigger.event().map) else {
-        return;
-    };
-
-    let map = trigger.event().map(&map_asset);
-    let layer = trigger.event().layer(&map_asset);
-    if settings.tiles_objects_filter == ObjectNames::None
-        || !ObjectNameFilter::from(&settings.tiles_layer_filter).contains(&layer.name)
-    {
-        return;
-    }
-
-    let objects_filter = &ObjectNameFilter::from(&settings.tiles_objects_filter);
-
-    if let Some(collision) = trigger
-        .event()
-        .layer(&map_asset)
-        .as_tile_layer()
-        .and_then(|tile_layer| {
-            tile_layer.get_tile(trigger.event().tiled_index.x, trigger.event().tiled_index.y)
-        })
-        .and_then(|layer_tile| layer_tile.get_tile())
-        .as_ref()
-        .and_then(|tile| tile.collision.as_ref())
-    {
-        // We need to add a Transform to our tile so Transform from
-        // the map and layers will be propagated down to the collider(s)
-        let world_position = trigger.event().world_position(&map_asset);
-        commands
-            .entity(trigger.event().tile)
-            .insert(Transform::from_xyz(world_position.x, world_position.y, 0.0));
-
-        for (object_id, object_data) in collision.object_data().iter().enumerate() {
-            if objects_filter.contains(&object_data.name) {
-                collider::spawn_collider::<T>(
-                    &settings.backend,
-                    &mut commands,
-                    &map_asset,
-                    &trigger.event().map_handle,
-                    &TiledColliderSource {
-                        entity: trigger.event().tile,
-                        ty: TiledColliderSourceType::new_tile(
-                            trigger.event().layer_id,
-                            trigger.event().tiled_index.x,
-                            trigger.event().tiled_index.y,
-                            object_id,
-                        ),
-                    },
-                    Vec2 {
-                        x: object_data.x - map.tile_width as f32 / 2.,
-                        y: (map.tile_height as f32 - object_data.y) - map.tile_height as f32 / 2.,
-                    },
-                );
-            }
-        }
     }
 }

--- a/src/physics/rapier.rs
+++ b/src/physics/rapier.rs
@@ -3,7 +3,10 @@
 //! Only available when the `rapier` feature is enabled.
 
 use bevy::prelude::*;
-use bevy_rapier2d::prelude::*;
+use bevy_rapier2d::{
+    prelude::*,
+    rapier::prelude::{Isometry, Real, SharedShape},
+};
 use tiled::{Map, ObjectShape};
 
 use crate::prelude::*;
@@ -27,92 +30,130 @@ impl TiledPhysicsBackend for TiledPhysicsRapierBackend {
         commands: &mut Commands,
         map: &Map,
         collider_source: &TiledColliderSource,
-    ) -> Option<TiledColliderSpawnInfos> {
-        // TODO: use this function once I figure out how to prevent cloning ObjectData
-        // let object_data = collider_source.object_data(map)?;
-
-        let tile = collider_source.tile(map);
-        let object = collider_source.object(map);
-
-        let object_data = (match collider_source.ty {
-            TiledColliderSourceType::Tile {
-                layer_id: _,
-                x: _,
-                y: _,
-                object_id,
-            } => tile
-                .as_ref()
-                .and_then(|tile| tile.collision.as_ref())
-                .map(|collision| collision.object_data())
-                .and_then(|objects| objects.get(object_id)),
+    ) -> Vec<TiledColliderSpawnInfos> {
+        match collider_source.ty {
             TiledColliderSourceType::Object {
                 layer_id: _,
                 object_id: _,
-            } => object.as_deref(),
-        })?;
-
-        let (pos, collider) = get_position_and_collider(&object_data.shape)?;
-
-        Some(TiledColliderSpawnInfos {
-            name: format!("Rapier[{}]", object_data.name),
-            entity: commands.spawn(collider).id(),
-            position: pos,
-            rotation: -object_data.rotation,
-        })
+            } => {
+                let Some(object) = collider_source.object(map) else {
+                    return vec![];
+                };
+                let Some((pos, shared_shape, _)) = get_position_and_shape(&object.shape) else {
+                    return vec![];
+                };
+                let collider: Collider = shared_shape.into();
+                vec![TiledColliderSpawnInfos {
+                    name: format!("Rapier[Object={}]", object.name),
+                    entity: commands.spawn(collider).id(),
+                    position: pos,
+                    rotation: -object.rotation,
+                }]
+            }
+            TiledColliderSourceType::TilesLayer { layer_id: _ } => {
+                let mut composables = vec![];
+                let mut spawn_infos = vec![];
+                for (tile_position, tile) in collider_source.tiles_from_layer(map) {
+                    if let Some(collision) = &tile.collision {
+                        for object in collision.object_data() {
+                            let object_position = Vec2 {
+                                x: object.x - map.tile_width as f32 / 2.,
+                                y: (map.tile_height as f32 - object.y)
+                                    - map.tile_height as f32 / 2.,
+                            };
+                            if let Some((mut position, shared_shape, is_composable)) =
+                                get_position_and_shape(&object.shape)
+                            {
+                                position += tile_position + object_position;
+                                position += Vec2 {
+                                    x: (map.tile_width as f32) / 2.,
+                                    y: (map.tile_height as f32) / 2.,
+                                };
+                                if is_composable {
+                                    composables.push((
+                                        Isometry::<Real>::new(
+                                            position.into(),
+                                            f32::to_radians(-object.rotation),
+                                        ),
+                                        shared_shape,
+                                    ));
+                                } else {
+                                    let collider: Collider = shared_shape.into();
+                                    spawn_infos.push(TiledColliderSpawnInfos {
+                                        name: "Rapier[ComplexTile]".to_string(),
+                                        entity: commands.spawn(collider).id(),
+                                        position,
+                                        rotation: -object.rotation,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                if !composables.is_empty() {
+                    let collider: Collider = SharedShape::compound(composables).into();
+                    spawn_infos.push(TiledColliderSpawnInfos {
+                        name: "Rapier[ComposedTile]".to_string(),
+                        entity: commands.spawn(collider).id(),
+                        position: Vec2::ZERO,
+                        rotation: 0.,
+                    });
+                }
+                spawn_infos
+            }
+        }
     }
 }
 
-fn get_position_and_collider(shape: &ObjectShape) -> Option<(Vect, Collider)> {
+fn get_position_and_shape(shape: &ObjectShape) -> Option<(Vec2, SharedShape, bool)> {
     match shape {
         ObjectShape::Rect { width, height } => {
-            // The origin is the top-left corner of the rectangle when not rotated.
-            let shape = Collider::cuboid(width / 2., height / 2.);
-            let pos = Vect::new(width / 2., -height / 2.);
-            Some((pos, shape))
+            let shape = SharedShape::cuboid(width / 2., height / 2.);
+            let pos = Vec2::new(width / 2., -height / 2.);
+            Some((pos, shape, true))
         }
         ObjectShape::Ellipse { width, height } => {
             let shape = if width > height {
-                Collider::capsule(
-                    Vec2::new((-width + height) / 2., 0.),
-                    Vec2::new((width - height) / 2., 0.),
+                SharedShape::capsule(
+                    Vec2::new((-width + height) / 2., 0.).into(),
+                    Vec2::new((width - height) / 2., 0.).into(),
                     height / 2.,
                 )
             } else {
-                Collider::capsule(
-                    Vec2::new(0., (-height + width) / 2.),
-                    Vec2::new(0., (height - width) / 2.),
+                SharedShape::capsule(
+                    Vec2::new(0., (-height + width) / 2.).into(),
+                    Vec2::new(0., (height - width) / 2.).into(),
                     width / 2.,
                 )
             };
-
-            let pos = Vect::new(width / 2., -height / 2.);
-            Some((pos, shape))
+            let pos = Vec2::new(width / 2., -height / 2.);
+            Some((pos, shape, true))
         }
         ObjectShape::Polyline { points } => {
-            let shape = Collider::polyline(
-                points.iter().map(|(x, y)| Vect::new(*x, -*y)).collect(),
-                None,
-            );
-            Some((Vect::ZERO, shape))
+            let vertices = points
+                .iter()
+                .map(|(x, y)| Vec2::new(*x, -*y))
+                .map(|v| v.into())
+                .collect();
+            let shape = SharedShape::polyline(vertices, None);
+            Some((Vec2::ZERO, shape, false))
         }
         ObjectShape::Polygon { points } => {
             if points.len() < 3 {
                 return None;
             }
 
-            let points = points
+            let vertices = points
                 .iter()
-                .map(|(x, y)| Vect::new(*x, -*y))
-                .collect::<Vec<_>>();
-
+                .map(|(x, y)| Vec2::new(*x, -*y))
+                .map(|v| v.into())
+                .collect();
             let indices = (0..points.len() as u32 - 1)
                 .map(|i| [i, i + 1])
                 .chain([[points.len() as u32 - 1, 0]])
                 .collect();
-
-            let shape = Collider::polyline(points, Some(indices));
-
-            Some((Vect::ZERO, shape))
+            let shape = SharedShape::polyline(vertices, Some(indices));
+            Some((Vec2::ZERO, shape, false))
         }
         _ => None,
     }


### PR DESCRIPTION
The goal is to reduce the overall number of colliders we spawn (right now, we have one per tile entity). It will improve performances:
- less colliders so less work for our physics engine
- no `Transform` anymore for tiles holding a collider

We cannot merge all colliders shapes, only the "basic" ones but they should be the most used anyway.
Colliders from tiles will now have their layer as parent.

No change for object colliders. We probably want to keep them as individual colliders and don't merge them:
- they can be interacted with / moved around (which is not really the case for tiles)
- they should not be an issue for performances since there are way less of them compared to tiles

Things remaining to do:
- [x] More tests
- [x] Update documentation (API ref + book if needed)
- [ ] Still a bug with objects with a non null rotation. They end up with a sligh offset from where they should be.