### PR TITLE
fix: handle missing map paths during debug and info logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Bugfixes
+
+-   Fixed debug and info logging in `process_loaded_maps` to handle cases where a map handle's path is unavailable, using the handle ID as a fallback.
+
 ## v0.5.0
 
 **BREAKING CHANGES**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,18 +146,26 @@ fn process_loaded_maps(
                 }
                 // If not fully loaded yet, insert the 'Respawn' marker so we will try to load it at next frame
                 commands.entity(map_entity).insert(RespawnTiledMap);
-                debug!(
-                    "Map '{}' is not fully loaded yet...",
-                    map_handle.0.path().unwrap()
-                );
+                if let Some(path) = map_handle.0.path() {
+                    debug!("Map '{}' is not fully loaded yet...", path);
+                } else {
+                    debug!(
+                        "Map with handle '{}' is not fully loaded yet...",
+                        map_handle.0.id()
+                    );
+                }
                 continue;
             }
 
             let tiled_map = maps.get(&map_handle.0).unwrap();
-            info!(
-                "Map '{}' has finished loading, spawn it",
-                map_handle.0.path().unwrap()
-            );
+            if let Some(path) = map_handle.0.path() {
+                info!("Map '{}' has finished loading, spawn it", path);
+            } else {
+                info!(
+                    "Map with handle '{}' has finished loading, spawn it",
+                    map_handle.0.id()
+                );
+            }
 
             // Clean map layers
             remove_layers(&mut commands, &mut tiled_id_storage);


### PR DESCRIPTION
Updated the `process_loaded_maps` function to account for cases where a map handle's path is unavailable.

Closes #69 