### PR TITLE
fix(#94): do not restrict `world_chunking` system to camera with `Changed<Transform>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add a new `TiledColliderCreated` event and an associated observer, when a new collider is spawned.
 
+### Bugfixes
+
+- Do not restrict `world_chunking` system to camera with `Changed<Transform>` (#94)
+
 ## v0.7.0
 
 **BREAKING CHANGES**

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -55,7 +55,7 @@ pub(crate) fn build(app: &mut bevy::prelude::App) {
 
 #[allow(clippy::type_complexity)]
 fn world_chunking(
-    camera_query: Query<&Transform, (With<Camera>, Changed<Transform>)>,
+    camera_query: Query<&Transform, With<Camera>>,
     worlds: Res<Assets<TiledWorld>>,
     asset_server: Res<AssetServer>,
     mut commands: Commands,


### PR DESCRIPTION
closes #94