### PR TITLE
fix(#96): properly spawn all maps from a world when not using chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Bugfixes
+
+- Properly spawn all maps from a world when not using chunking, we were missing the last one (#96)
+
 ## v0.7.1
 
 ### Features

--- a/examples/world_basic.rs
+++ b/examples/world_basic.rs
@@ -31,6 +31,5 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // But you can add extra components to change the defaults settings and how
         // your world is actually displayed
         TilemapAnchor::Center,
-        TiledWorldChunking::new(200., 200.),
     ));
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -144,7 +144,7 @@ fn world_chunking(
             }
         } else if storage.spawned_maps.is_empty() {
             // No chunking and we don't have spawned any map yet: just spawn all maps
-            for idx in 0..tiled_world.maps.len() - 1 {
+            for idx in 0..tiled_world.maps.len() {
                 to_spawn.push(idx);
             }
         }


### PR DESCRIPTION
Fix #96 