### PR TITLE
fix(#115): avoid crash when targeting 'wasm'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Bugfixes
+
+- Avoid crash when targeting `wasm` (#115).
+
 ## v0.7.4
 
 ### Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub struct TiledMapPluginConfig {
 
 impl Default for TiledMapPluginConfig {
     fn default() -> Self {
-        let mut path = env::current_dir().unwrap();
+        let mut path = env::current_dir().unwrap_or_default();
         path.push("tiled_types_export.json");
         Self {
             tiled_types_export_file: Some(path),


### PR DESCRIPTION
@zbuc can you please test this fix ?

closes #115 