### PR TITLE
fix(#119): support scaling tile objects from image collections

### DIFF
--- a/src/physics/collider.rs
+++ b/src/physics/collider.rs
@@ -109,11 +109,19 @@ pub(crate) fn spawn_colliders<T: TiledPhysicsBackend>(
                             return vec![];
                         };
 
+                        let unscaled_tile_size = match &tile.image {
+                            Some(image) => {
+                                // tile is in image collection
+                                Vec2::new(image.width as f32, image.height as f32)
+                            }
+                            None => Vec2::new(
+                                tile.tileset().tile_width as f32,
+                                tile.tileset().tile_height as f32,
+                            ),
+                        };
+
                         let mut offset = Vec2::ZERO;
-                        let mut scale = Vec2::new(
-                            width / tile.tileset().tile_width as f32,
-                            height / tile.tileset().tile_height as f32,
-                        );
+                        let mut scale = Vec2::new(width, height) / unscaled_tile_size;
                         if object_tile.flip_h {
                             scale.x *= -1.;
                             offset.x += width;


### PR DESCRIPTION
To test, I added a simple image collection with differing sizes to one of the example maps.
A copy of these new tiles but scaled and distorted were included alongside.
Before:
<img width="800" height="600" alt="before" src="https://github.com/user-attachments/assets/adf22e45-d8de-4bd4-88ba-d035c2a3a1f7" />
After:
<img width="800" height="600" alt="after" src="https://github.com/user-attachments/assets/ff5afa85-bf4b-4679-aef6-3504b6702b97" />
(I can include these extra changes or moved them to another example map if requested)