### PR TITLE
fix: support negative drawing offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Bugfixes
+
+- Fix crash with negative drawing offsets and ensure positive offsets are handled correctly (#122).
+
 ## v0.8.1
 
 ### Bugfixes

--- a/src/physics/collider.rs
+++ b/src/physics/collider.rs
@@ -69,7 +69,11 @@ impl<'a> TiledEvent<ColliderCreated> {
                             &map_type,
                             anchor,
                         );
-                        out.push((tile_coords, tile));
+                        let offset = Vec2::new(
+                            tile.tileset().offset_x as f32,
+                            -tile.tileset().offset_y as f32,
+                        );
+                        out.push((tile_coords + offset, tile));
                     }
                 });
                 out
@@ -120,8 +124,11 @@ pub(crate) fn spawn_colliders<T: TiledPhysicsBackend>(
                             ),
                         };
 
-                        let mut offset = Vec2::ZERO;
                         let mut scale = Vec2::new(width, height) / unscaled_tile_size;
+                        let mut offset = Vec2::new(
+                            tile.tileset().offset_x as f32,
+                            -tile.tileset().offset_y as f32,
+                        ) * scale;
                         if object_tile.flip_h {
                             scale.x *= -1.;
                             offset.x += width;

--- a/src/tiled/map/asset.rs
+++ b/src/tiled/map/asset.rs
@@ -16,6 +16,8 @@ pub(crate) struct TiledMapTileset {
     /// A tileset can be used for tiles layer only if all the images it contains have the
     /// same dimensions (restriction from bevy_ecs_tilemap).
     pub(crate) usable_for_tiles_layer: bool,
+    /// The offset to be used when drawing tiles from this tileset.
+    pub(crate) drawing_offset: IVec2,
     /// Tileset texture (ie. a single image or an images collection)
     pub(crate) tilemap_texture: TilemapTexture,
     /// The [`TextureAtlasLayout`] handle associated to each tileset, if any.

--- a/src/tiled/map/asset.rs
+++ b/src/tiled/map/asset.rs
@@ -16,8 +16,6 @@ pub(crate) struct TiledMapTileset {
     /// A tileset can be used for tiles layer only if all the images it contains have the
     /// same dimensions (restriction from bevy_ecs_tilemap).
     pub(crate) usable_for_tiles_layer: bool,
-    /// The offset to be used when drawing tiles from this tileset.
-    pub(crate) drawing_offset: IVec2,
     /// Tileset texture (ie. a single image or an images collection)
     pub(crate) tilemap_texture: TilemapTexture,
     /// The [`TextureAtlasLayout`] handle associated to each tileset, if any.

--- a/src/tiled/map/loader.rs
+++ b/src/tiled/map/loader.rs
@@ -343,11 +343,8 @@ fn tileset_to_tiled_map_tileset(
                             UVec2::new(tileset.tile_width, tileset.tile_height),
                             columns,
                             tileset.tilecount / columns,
-                            Some(UVec2::new(tileset.spacing, tileset.spacing)),
-                            Some(UVec2::new(
-                                tileset.offset_x as u32 + tileset.margin,
-                                tileset.offset_y as u32 + tileset.margin,
-                            )),
+                            Some(UVec2::splat(tileset.spacing)),
+                            Some(UVec2::splat(tileset.margin)),
                         )
                     }));
             }
@@ -358,6 +355,7 @@ fn tileset_to_tiled_map_tileset(
 
     Some(TiledMapTileset {
         usable_for_tiles_layer,
+        drawing_offset: IVec2::new(tileset.offset_x, tileset.offset_y),
         tilemap_texture,
         texture_atlas_layout_handle,
         #[cfg(not(feature = "atlas"))]

--- a/src/tiled/map/loader.rs
+++ b/src/tiled/map/loader.rs
@@ -355,7 +355,6 @@ fn tileset_to_tiled_map_tileset(
 
     Some(TiledMapTileset {
         usable_for_tiles_layer,
-        drawing_offset: IVec2::new(tileset.offset_x, tileset.offset_y),
         tilemap_texture,
         texture_atlas_layout_handle,
         #[cfg(not(feature = "atlas"))]

--- a/src/tiled/map/spawn.rs
+++ b/src/tiled/map/spawn.rs
@@ -426,10 +426,21 @@ fn spawn_objects_layer(
         // and possibly an animation component if the tile is animated.
         match handle_tile_object(&object_data, tiled_map) {
             (Some((sprite, offset_transform)), None) => {
-                commands.spawn((ChildOf(object_entity), sprite, offset_transform));
+                commands.spawn((
+                    Name::new("TileVisual"),
+                    ChildOf(object_entity),
+                    sprite,
+                    offset_transform,
+                ));
             }
             (Some((sprite, offset_transform)), Some(animation)) => {
-                commands.spawn((ChildOf(object_entity), sprite, offset_transform, animation));
+                commands.spawn((
+                    Name::new("TileVisual"),
+                    ChildOf(object_entity),
+                    sprite,
+                    offset_transform,
+                    animation,
+                ));
             }
             _ => {}
         };


### PR DESCRIPTION
Tiled's drawing offset was previously cast to u32
and added to the atlas margin, causing crashes when tilesets used negative offsets.

Negative drawing offsets can be useful, for example, to simulate alternative anchors (since Tiled's tile anchors are always bottom left)

This change removes the tileset's drawing offset from the atlas margin and instead applies it as a Transform to the tilemap_entity.