### PR TITLE
fix(#127): image layers position when tiles size do not match the grid size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ A [migration guide](https://adrien-bon.github.io/bevy_ecs_tiled/migrations/v0_9.
 ### Changed
 
 - Rationalize usage of  `tile_size` vs. `grid_size`
+- Deduce the largest `tile_size` of a given map and use that to
+  perform map-level operations needing a `tile_size` instead of relying upong the `grid_size`
 
 ### Bugfixes
 
 - Break apart object layer colliders and project to isometric coords (#32)
+- Image layers on isometric maps are not properly positioned (#127)
 
 ## v0.8.2
 

--- a/book/src/migrations/v0_9.md
+++ b/book/src/migrations/v0_9.md
@@ -27,6 +27,9 @@ This guide outlines the steps required to migrate your project to version `0.9` 
   `tile_size_from_grid_size()` has been removed.  
   *Reason:* Avoids confusion between `tile_size` and `grid_size`.
 
+  `tile_size_from_map()` has been removed.  
+  *Reason:* You should use `TiledMapAsset::largest_tile_size` instead.
+
 - **Added:**  
   A new `tile_size()` helper function is available to retrieve the `tile_size` from a `Tile`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub mod prelude {
         filter::TiledFilter,
         helpers::{
             get_layer_from_map, get_object_from_map, get_tile_from_map, get_tileset_from_map,
-            grid_size_from_map, tile_size, tile_size_from_map, tilemap_type_from_map,
+            grid_size_from_map, tile_size, tilemap_type_from_map,
         },
         image::TiledImage,
         layer::TiledLayer,

--- a/src/tiled/helpers.rs
+++ b/src/tiled/helpers.rs
@@ -100,20 +100,6 @@ pub fn tile_size(tile: &Tile) -> TilemapTileSize {
     }
 }
 
-/// Converts a [`Map`]'s grid size to a [`TilemapTileSize`].
-///
-/// The width and height will be the same as those given by [`grid_size_from_map`].
-///
-/// **Note:** this value is given from the Tiled map 'Tile Width' and 'Tile Height'
-/// properties. It can be different from the size given by the tileset, which you can
-/// retrieve with the [`tile_size`] function.
-pub fn tile_size_from_map(map: &Map) -> TilemapTileSize {
-    TilemapTileSize {
-        x: map.tile_width as f32,
-        y: map.tile_height as f32,
-    }
-}
-
 /// Projects Tiled isometric coordinates into scalar coordinates for Bevy.
 ///
 /// Used to convert isometric tile coordinates into world-space positions for rendering.

--- a/src/tiled/map/asset.rs
+++ b/src/tiled/map/asset.rs
@@ -34,11 +34,17 @@ pub struct TiledMapAsset {
     pub map: tiled::Map,
     /// Map size in tiles
     pub tilemap_size: TilemapSize,
-    /// Map bounding box, unanchored.
+    /// The largest tile size, in pixels, found among all tiles from this map
+    ///
+    /// You should only rely on this value for "map-level" concerns.
+    /// If you want to get the actual size of a given tile, you should instead
+    /// use the [`tile_size`] function.
+    pub largest_tile_size: TilemapTileSize,
+    /// Map bounding box, unanchored, in pixels.
     ///
     /// Origin it map bottom-left.
-    /// Minimum is set at `(0., 0.)`
-    /// Maximum is set at `(map_size.x, map_size.y)`
+    /// Minimum is `(0., 0.)`
+    /// Maximum is `(map_size.x, map_size.y)`
     pub rect: Rect,
     /// Offset to apply on Tiled coordinates when converting to Bevy coordinates
     ///
@@ -75,10 +81,10 @@ impl TiledMapAsset {
         tiled_position: Vec2,
     ) -> Vec2 {
         let map_size = self.tilemap_size;
+        let tile_size = self.largest_tile_size;
         let map_height = self.rect.height();
         let grid_size = grid_size_from_map(&self.map);
         let map_type = tilemap_type_from_map(&self.map);
-        let tile_size = tile_size_from_map(&self.map);
         let mut offset = anchor.as_offset(&map_size, &grid_size, &tile_size, &map_type);
         offset.x -= grid_size.x / 2.0;
         offset.y -= grid_size.y / 2.0;
@@ -282,6 +288,7 @@ impl fmt::Debug for TiledMapAsset {
         f.debug_struct("TiledMapAsset")
             .field("map", &self.map)
             .field("tilemap_size", &self.tilemap_size)
+            .field("largest_tile_size", &self.largest_tile_size)
             .field("rect", &self.rect)
             .field("tiled_offset", &self.tiled_offset)
             .field("topleft_chunk", &self.topleft_chunk)


### PR DESCRIPTION
* Make sure we get the proper tile_size by parsing the map beforehand Also fixes image layer anchoring as a side effect

closes #127 