### PR TITLE
feat: add a new marker component, 'TiledObjectVisual', to help identify the 'Entity' holding the visual representation of a 'TiledObject::Tile'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `TiledParallaxCamera` camera marker component to choose the camera used for map layers parallax calculations.
 - `ImageLayer`'s `Image` should be loaded during map loading and not during map spawning (#118)
+- Add a new marker component, `TiledObjectVisual`, to help identify the `Entity` holding the visual representation of a `TiledObject::Tile`
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub mod prelude {
             asset::TiledMapAsset, loader::TiledMapLoaderError, storage::TiledMapStorage,
             RespawnTiledMap, TiledMap, TiledMapLayerZOffset,
         },
-        object::TiledObject,
+        object::{TiledObject, TiledObjectVisual},
         sets::{TiledPostUpdateSystems, TiledPreUpdateSystems, TiledUpdateSystems},
         tile::{TiledTile, TiledTilemap},
         world::{

--- a/src/tiled/map/spawn.rs
+++ b/src/tiled/map/spawn.rs
@@ -435,6 +435,7 @@ fn spawn_objects_layer(
             (Some((sprite, offset_transform)), None) => {
                 commands.spawn((
                     Name::new("TileVisual"),
+                    TiledObjectVisual,
                     ChildOf(object_entity),
                     sprite,
                     offset_transform,
@@ -443,6 +444,7 @@ fn spawn_objects_layer(
             (Some((sprite, offset_transform)), Some(animation)) => {
                 commands.spawn((
                     Name::new("TileVisual"),
+                    TiledObjectVisual,
                     ChildOf(object_entity),
                     sprite,
                     offset_transform,

--- a/src/tiled/object.rs
+++ b/src/tiled/object.rs
@@ -8,6 +8,14 @@ use bevy::prelude::*;
 use geo::Centroid;
 use tiled::{ObjectData, ObjectShape};
 
+/// Marker [`Component`] for the visual representation of a [`TiledObject`].
+///
+/// Added on the child [`Entity`] of a [`TiledObject::Tile`].
+#[derive(Component, Default, Reflect, Clone, Copy, Debug)]
+#[reflect(Component, Default, Debug)]
+#[require(Visibility, Transform, Sprite)]
+pub struct TiledObjectVisual;
+
 /// Marker [`Component`] for a Tiled map object.
 #[derive(Component, Default, Reflect, Clone, Debug)]
 #[reflect(Component, Default, Debug)]
@@ -314,4 +322,5 @@ impl TiledObject {
 
 pub(crate) fn plugin(app: &mut App) {
     app.register_type::<TiledObject>();
+    app.register_type::<TiledObjectVisual>();
 }


### PR DESCRIPTION
May help for #136 