### PR TITLE
update docs to use TiledFilter::Names instead of old ObjectNames::Names

### DIFF
--- a/book/src/guides/physics.md
+++ b/book/src/guides/physics.md
@@ -109,8 +109,8 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // - objects named 'hitbox' or 'collision'
         // - tile colliders in a layer named 'collision'
         TiledPhysicsSettings::<TiledPhysicsAvianBackend> {
-            objects_filter: ObjectNames::Names(vec!["hitbox".into(), "collision".into()]),
-            tiles_layer_filter: ObjectNames::Names(vec!["collision".into()]),
+            objects_filter: TiledFilter::Names(vec!["hitbox".into(), "collision".into()]),
+            tiles_layer_filter: TiledFilter::Names(vec!["collision".into()]),
             ..default()
         },
     ));


### PR DESCRIPTION
While adding physics I noticed the docs were slightly out of date. 