### PR TITLE
Implement minimap for the demo platformer

### DIFF
--- a/examples/demo_platformer/camera.rs
+++ b/examples/demo_platformer/camera.rs
@@ -11,12 +11,21 @@ pub(super) fn plugin(app: &mut App) {
     );
 }
 
+#[derive(Component)]
+pub struct MainCamera;
+
 fn setup_camera(mut commands: Commands) {
-    commands.spawn((Name::new("Camera"), Camera2d, TiledParallaxCamera));
+    commands.spawn((
+        Name::new("Camera"),
+        Camera2d,
+        MainCamera,
+        TiledParallaxCamera,
+        IsDefaultUiCamera,
+    ));
 }
 
 fn camera_follow_player(
-    camera_single: Single<&mut Transform, With<Camera2d>>,
+    camera_single: Single<&mut Transform, With<MainCamera>>,
     player_single: Single<&GlobalTransform, With<Player>>,
 ) {
     let mut camera_transform = camera_single.into_inner();

--- a/examples/demo_platformer/level.rs
+++ b/examples/demo_platformer/level.rs
@@ -1,6 +1,7 @@
 use avian2d::prelude::*;
 use bevy::prelude::*;
 use bevy_ecs_tiled::prelude::*;
+use bevy::render::view::RenderLayers;
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(Startup, startup);
@@ -15,6 +16,24 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .observe(
             |t: Trigger<TiledEvent<ColliderCreated>>, mut commands: Commands| {
                 commands.entity(t.event().origin).insert(RigidBody::Static);
+            },
+        )
+        .observe(
+            |trigger: Trigger<TiledEvent<LayerCreated>>,
+             layers_query: Query<(Entity, &TiledLayer)>,
+             children_query: Query<&Children>,
+             mut commands: Commands| {
+                let Ok((layer_entity, layer)) = layers_query.get(trigger.event().origin) else {
+                    return;
+                };
+                if !matches!(layer, TiledLayer::Tiles) {
+                    return;
+                }
+                for e in std::iter::once(layer_entity).chain(children_query.iter_descendants(layer_entity)) {
+                    commands
+                        .entity(e)
+                        .insert(RenderLayers::from_layers(&[0, 1])); // Also appear on minimap
+                }
             },
         );
 }

--- a/examples/demo_platformer/main.rs
+++ b/examples/demo_platformer/main.rs
@@ -11,6 +11,7 @@ mod debug;
 mod enemy;
 mod level;
 mod player;
+mod minimap;
 
 fn main() {
     let mut app = App::new();
@@ -58,6 +59,7 @@ fn main() {
         enemy::plugin,
         level::plugin,
         controller::CharacterControllerPlugin,
+        minimap::plugin,
     ));
 
     let mut path = env::current_dir().unwrap();

--- a/examples/demo_platformer/minimap.rs
+++ b/examples/demo_platformer/minimap.rs
@@ -1,0 +1,43 @@
+use bevy::prelude::*;
+use bevy::render::camera::Viewport;
+use bevy::render::view::RenderLayers;
+
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_systems(Startup, setup_minimap);
+}
+
+fn setup_minimap(mut commands: Commands, window: Single<&Window>) {
+    let mut minimap_projection = OrthographicProjection::default_2d();
+    minimap_projection.scale = 16.0;
+    let minimap_width = 400;
+    let minimap_height = 300;
+    commands.spawn((
+        Name::new("Minimap Camera"),
+        Camera2d,
+        Projection::Orthographic(minimap_projection),
+        Camera {
+            viewport: Some(Viewport {
+                physical_position: UVec2::new(0, 0),
+                physical_size: UVec2::new(minimap_width, minimap_height),
+                ..default()
+            }),
+            order: 1, // After main camera at default order 0
+            ..default()
+        },
+        RenderLayers::layer(1),
+    ));
+
+    // Minimap blue-ish background
+    commands.spawn((
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(0.0),
+            left: Val::Px(0.0),
+            width: Val::Px(minimap_width as f32 / window.resolution.scale_factor()),
+            height: Val::Px(minimap_height as f32 / window.resolution.scale_factor()),
+            ..default()
+        },
+        BackgroundColor(Color::srgba(0.243, 0.361, 0.522, 0.82)),
+    ));
+}

--- a/examples/demo_platformer/player.rs
+++ b/examples/demo_platformer/player.rs
@@ -8,7 +8,7 @@ use crate::{
     UpdateSystems,
 };
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::Anchor};
+use bevy::{prelude::*, sprite::Anchor, render::view::RenderLayers};
 
 const PLAYER_SPRITE_FILE: &str =
     "demo_platformer/kenney_platformer-pack-redux/Spritesheets/spritesheet_players.png";
@@ -89,6 +89,18 @@ fn spawn_player_at_spawn_point(
             600.,
             PI * 0.45,
         ),
+        children![
+            (
+                Name::new("Player Minimap Marker"),
+                Sprite {
+                    custom_size: Some(Vec2::new(32., 96.)),
+                    color: Color::srgb(1.0, 0.0, 0.0),
+                    ..default()
+                },
+                Transform::from_xyz(0., 0., 100.0),
+                RenderLayers::layer(1) // Render on minimap, inherit position from parent
+            )
+        ]
     ));
 }
 


### PR DESCRIPTION
* New camera in viewport on the top left screen
  * Renders from [RenderLayer](https://docs.rs/bevy/latest/bevy/camera/visibility/struct.RenderLayers.html) 1
  * Main camera renders RenderLayers 0
* Add observer to map spawn to iterate layer children to set them as RenderLayers 0 and 1
  * so they'll appear on both the main camera and the minimap
* Only the main camera follows the player, minimap camera stays static
* Player is now spawned with a child minimap marker on RenderLayers 1
  * but it inherits the position from the parent.
* Add a nice background to the minimap.