### PR TITLE
fix(#159): Fix compilation failure with `ReflectMut::Function` when `reflect_functions` Bevy feature is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+### Bugfixes
+
+- Fix compilation failure with `ReflectMut::Function` when `reflect_functions` Bevy feature is enabled (#159)
+
 ## v0.9.5
 
 ### Features

--- a/src/tiled/properties/load.rs
+++ b/src/tiled/properties/load.rs
@@ -649,7 +649,7 @@ fn hydrate(object: &mut dyn PartialReflect, obj_entity_map: &HashMap<u32, Entity
         // Cannot hydrate a Set since it does not have a get_mut() function
         ReflectMut::Set(_) => {}
         // we don't care about any of the other values
-        ReflectMut::Opaque(_) => {}
+        _ => {}
     }
 }
 


### PR DESCRIPTION
closes #159 