### PR TITLE
bump to bevy version 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ user_properties = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
 # Main dependencies
-bevy = { version = "0.16", default-features = false }
-bevy_ecs_tilemap = { version = "0.16", default-features = false }
+bevy = { version = "0.17", default-features = false }
+bevy_ecs_tilemap = { version = "0.17", default-features = false }
 tiled = { version = "0.15", features = ["world"] }
 
 # Utilities
@@ -59,7 +59,7 @@ regex = "1.11"
 
 # Optional dependencies, enabled via features.
 bevy_rapier2d = { version = "0.31", optional = true }
-avian2d = { version = "0.3", optional = true }
+avian2d = { version = "0.4", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 
@@ -75,8 +75,8 @@ max_combination_size = 3
 denylist = ["png", "bmp", "jpeg", "gif"]
 
 [dev-dependencies]
-bevy = { version = "0.16", features = ["file_watcher"] }
-bevy-inspector-egui = "0.33"
+bevy = { version = "0.17", features = ["file_watcher"] }
+bevy-inspector-egui = "0.34"
 iyes_perf_ui = { version = "0.5" }
 
 [[example]]

--- a/examples/helper/camera.rs
+++ b/examples/helper/camera.rs
@@ -26,7 +26,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use bevy::{input::ButtonInput, math::Vec3, prelude::*, render::camera::Camera};
+use bevy::{input::ButtonInput, math::Vec3, prelude::*};
 
 const MINIMUM_SCALE: f32 = 0.1;
 

--- a/src/tiled/event.rs
+++ b/src/tiled/event.rs
@@ -29,8 +29,7 @@ use crate::tiled::{
 /// Wrapper around Tiled events
 ///
 /// Contains generic informations about origin of a particular Tiled event
-#[derive(Event, Clone, Copy, PartialEq, Debug, Reflect, Component)]
-#[event(auto_propagate, traversal = &'static ChildOf)]
+#[derive(Message, Clone, Copy, PartialEq, Debug, Reflect, Component)]
 #[reflect(Component, Debug, Clone)]
 pub struct TiledEvent<E: Debug + Clone + Copy + Reflect> {
     /// The original target of this event, before bubbling
@@ -120,9 +119,8 @@ where
     }
 
     /// Trigger observer and write event for this [`TiledEvent`]
-    pub fn send(&self, commands: &mut Commands, event_writer: &mut EventWriter<TiledEvent<E>>) {
-        commands.trigger_targets(*self, self.origin);
-        event_writer.write(*self);
+    pub fn send(&self, message_writer: &mut MessageWriter<TiledEvent<E>>) {
+        message_writer.write(*self);
     }
 }
 
@@ -295,17 +293,17 @@ pub struct ObjectCreated;
 #[derive(SystemParam)]
 pub(crate) struct TiledEventWriters<'w> {
     /// World events writer
-    pub world_created: EventWriter<'w, TiledEvent<WorldCreated>>,
+    pub world_created: MessageWriter<'w, TiledEvent<WorldCreated>>,
     /// Map events writer
-    pub map_created: EventWriter<'w, TiledEvent<MapCreated>>,
+    pub map_created: MessageWriter<'w, TiledEvent<MapCreated>>,
     /// Layer events writer
-    pub layer_created: EventWriter<'w, TiledEvent<LayerCreated>>,
+    pub layer_created: MessageWriter<'w, TiledEvent<LayerCreated>>,
     /// Tilemap events writer
-    pub tilemap_created: EventWriter<'w, TiledEvent<TilemapCreated>>,
+    pub tilemap_created: MessageWriter<'w, TiledEvent<TilemapCreated>>,
     /// Tile events writer
-    pub tile_created: EventWriter<'w, TiledEvent<TileCreated>>,
+    pub tile_created: MessageWriter<'w, TiledEvent<TileCreated>>,
     /// Object events writer
-    pub object_created: EventWriter<'w, TiledEvent<ObjectCreated>>,
+    pub object_created: MessageWriter<'w, TiledEvent<ObjectCreated>>,
 }
 
 impl fmt::Debug for TiledEventWriters<'_> {
@@ -315,16 +313,16 @@ impl fmt::Debug for TiledEventWriters<'_> {
 }
 
 pub(crate) fn plugin(app: &mut App) {
-    app.add_event::<TiledEvent<WorldCreated>>()
+    app.add_message::<TiledEvent<WorldCreated>>()
         .register_type::<TiledEvent<WorldCreated>>();
-    app.add_event::<TiledEvent<MapCreated>>()
+    app.add_message::<TiledEvent<MapCreated>>()
         .register_type::<TiledEvent<MapCreated>>();
-    app.add_event::<TiledEvent<LayerCreated>>()
+    app.add_message::<TiledEvent<LayerCreated>>()
         .register_type::<TiledEvent<LayerCreated>>();
-    app.add_event::<TiledEvent<TilemapCreated>>()
+    app.add_message::<TiledEvent<TilemapCreated>>()
         .register_type::<TiledEvent<TilemapCreated>>();
-    app.add_event::<TiledEvent<TileCreated>>()
+    app.add_message::<TiledEvent<TileCreated>>()
         .register_type::<TiledEvent<TileCreated>>();
-    app.add_event::<TiledEvent<ObjectCreated>>()
+    app.add_message::<TiledEvent<ObjectCreated>>()
         .register_type::<TiledEvent<ObjectCreated>>();
 }

--- a/src/tiled/map/loader.rs
+++ b/src/tiled/map/loader.rs
@@ -396,16 +396,20 @@ fn tileset_to_tiled_map_tileset(
             let columns = (img.width as u32 - tileset.margin + tileset.spacing)
                 / (tileset.tile_width + tileset.spacing);
             if columns > 0 {
-                texture_atlas_layout_handle =
-                    Some(load_context.labeled_asset_scope(path.to_owned(), |_| {
-                        TextureAtlasLayout::from_grid(
+                texture_atlas_layout_handle = if let Ok(handle_asset) = load_context
+                    .labeled_asset_scope(path.to_owned(), |_| {
+                        Ok::<TextureAtlasLayout, TiledMapLoaderError>(TextureAtlasLayout::from_grid(
                             UVec2::new(tileset.tile_width, tileset.tile_height),
                             columns,
                             tileset.tilecount / columns,
                             Some(UVec2::splat(tileset.spacing)),
                             Some(UVec2::splat(tileset.margin)),
-                        )
-                    }));
+                        ))
+                    }) {
+                    Some(handle_asset)
+                } else {
+                    None
+                };
             }
 
             (true, TilemapTexture::Single(texture.clone()))

--- a/src/tiled/map/mod.rs
+++ b/src/tiled/map/mod.rs
@@ -232,7 +232,7 @@ fn process_loaded_maps(
 /// System to update maps as they are changed or removed.
 fn handle_map_events(
     mut commands: Commands,
-    mut map_events: EventReader<AssetEvent<TiledMapAsset>>,
+    mut map_events: MessageReader<AssetEvent<TiledMapAsset>>,
     map_query: Query<(Entity, &TiledMap)>,
     mut cache: ResMut<TiledResourceCache>,
 ) {

--- a/src/tiled/properties/load.rs
+++ b/src/tiled/properties/load.rs
@@ -323,11 +323,11 @@ impl DeserializedProperties {
                 if o == 0 {
                     Err("empty object reference".to_string())
                 } else {
-                    Ok(Box::new(Entity::from_raw(o)))
+                    Ok(Box::new(Entity::from_raw_u32 (o)))
                 }
             }
             ("core::option::Option<bevy_ecs::entity::Entity>", PV::ObjectValue(o), _) => {
-                Ok(Box::new(Some(Entity::from_raw(o)).filter(|_| o != 0)))
+                Ok(Box::new(Some(Entity::from_raw_u32 (o)).filter(|_| o != 0)))
             }
             (_, PV::StringValue(s), TypeInfo::Enum(info)) => {
                 let Some(variant) = info.variant(&s) else {
@@ -638,12 +638,10 @@ fn hydrate(object: &mut dyn PartialReflect, obj_entity_map: &HashMap<u32, Entity
             _ => {}
         },
         ReflectMut::Map(s) => {
-            for i in 0..s.len() {
-                let (k, v) = s.get_at_mut(i).unwrap();
-                if object_ref(k, obj_entity_map).is_some() {
-                    panic!("Unable to hydrate a key in a map!");
-                }
-                hydrate(v, obj_entity_map);
+            for i in s.iter() {
+                if let Ok(mut value) = i.0.reflect_clone() {
+                    hydrate(value.as_mut(), obj_entity_map);
+                }                
             }
         }
         // Cannot hydrate a Set since it does not have a get_mut() function

--- a/src/tiled/world/chunking.rs
+++ b/src/tiled/world/chunking.rs
@@ -136,7 +136,7 @@ fn handle_world_chunking(
             let map_entity = commands
                 .spawn((
                     ChildOf(world_entity),
-                    TiledMap(handle.clone_weak()),
+                    TiledMap(handle.clone()),
                     Transform::from_translation(
                         offset.extend(0.0) + Vec3::new(rect.min.x, rect.max.y, 0.0),
                     ),

--- a/src/tiled/world/mod.rs
+++ b/src/tiled/world/mod.rs
@@ -155,7 +155,7 @@ fn process_loaded_worlds(
 
             TiledEvent::new(world_entity, WorldCreated)
                 .with_world(world_entity, world_handle.0.id())
-                .send(&mut commands, &mut event_writers.world_created);
+                .send(&mut event_writers.world_created);
         }
     }
 }
@@ -163,7 +163,7 @@ fn process_loaded_worlds(
 /// System to update worlds as they are changed or removed.
 fn handle_world_events(
     mut commands: Commands,
-    mut world_events: EventReader<AssetEvent<TiledWorldAsset>>,
+    mut world_events: MessageReader<AssetEvent<TiledWorldAsset>>,
     world_query: Query<(Entity, &TiledWorld)>,
 ) {
     for event in world_events.read() {


### PR DESCRIPTION
My update involved some important choices:
- TiledEvent derives Message instead of Event => MessageReader and MessageWriter instead of EventReader and EventWriter. The message can't be used in observable handlers and command.trigger can't trigger messages. They can both be derived but it seems to me that the buffered way is more 