### PR TITLE
feat(#17): implement group layers

### DIFF
--- a/assets/maps/orthogonal/group_layers.tmx
+++ b/assets/maps/orthogonal/group_layers.tmx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="9" nextobjectid="38">
+ <tileset firstgid="1" source="../../tiles/orthogonal_1.tsx"/>
+ <group id="7" name="Parent">
+  <group id="8" name="Intermediate">
+   <objectgroup id="5" name="Collisions">
+    <object id="3" x="33" y="226" width="254" height="61">
+     <ellipse/>
+    </object>
+    <object id="5" x="223" y="31" width="63" height="252">
+     <ellipse/>
+    </object>
+    <object id="6" x="-40.5372" y="-21.2942" width="116" height="28.6476" rotation="20.3824">
+     <ellipse/>
+    </object>
+    <object id="8" x="56.0546" y="102.91" rotation="56.7816">
+     <polygon points="0,0 96,-31 158,-31 158,0 63,31 1,31"/>
+    </object>
+    <object id="34" gid="1073741828" x="357.333" y="446.667" width="117.333" height="260.667"/>
+    <object id="36" gid="2147483655" x="57.4329" y="-168.119" width="216.076" height="112.596" rotation="10.3481"/>
+    <object id="37" gid="2147483653" x="371.98" y="-53.2847" width="152" height="89" rotation="55.0381"/>
+   </objectgroup>
+   <imagelayer id="6" name="Image Layer 1" offsetx="32.6667" offsety="112.667" repeaty="1">
+    <image source="../../bevy_icon.png" width="257" height="247"/>
+   </imagelayer>
+  </group>
+  <layer id="1" name="Tile Layer 1" width="10" height="10">
+   <data encoding="csv">
+2,2,2,2,2,2,2,2,2,2,
+2,0,0,0,0,0,0,0,0,2,
+2,0,7,7,7,7,7,7,7,2,
+2,0,0,0,0,0,0,0,0,2,
+2,0,0,0,5,5,0,0,0,2,
+2,5,5,0,0,0,0,5,5,2,
+2,0,0,0,0,0,0,0,0,2,
+2,3,3,3,3,3,3,3,0,2,
+2,0,0,0,0,0,0,0,0,2,
+2,2,2,2,2,2,2,2,2,2
+</data>
+  </layer>
+ </group>
+</map>

--- a/examples/map_group_layers.rs
+++ b/examples/map_group_layers.rs
@@ -1,0 +1,35 @@
+//! This example shows the basic usage of the plugin.
+
+use bevy::prelude::*;
+use bevy_ecs_tiled::prelude::*;
+
+mod helper;
+
+fn main() {
+    App::new()
+        // Bevy default plugins: prevent blur effect by changing default sampling
+        .add_plugins(DefaultPlugins.build().set(ImagePlugin::default_nearest()))
+        // Add bevy_ecs_tiled plugin: bevy_ecs_tilemap::TilemapPlugin will
+        // be automatically added as well if it's not already done
+        .add_plugins(TiledPlugin::default())
+        // Examples helper plugins, such as the logic to pan and zoom the camera
+        // This should not be used directly in your game (but you can always have a look)
+        .add_plugins(helper::HelperPlugin)
+        // Add our systems and run the app!
+        .add_systems(Startup, startup)
+        .run();
+}
+
+fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // Spawn a 2D camera (required by Bevy)
+    commands.spawn(Camera2d);
+
+    // Load a map then spawn it
+    commands.spawn((
+        // Only the [`TiledMap`] component is actually required to spawn a map.
+        TiledMap(asset_server.load("maps/orthogonal/group_layers.tmx")),
+        // But you can add extra components to change the defaults settings and how
+        // your map is actually displayed
+        TilemapAnchor::Center,
+    ));
+}


### PR DESCRIPTION
I've implemented group layers based on your suggestions in #17 

The main issue I ran into while testing was that image layers inside groups wouldn't load properly. Ultimately my solution was to switch from calling `.layers().enumerate()` to get an index and instead just use `layer.id()` so it would line up between the code in `map/loader.rs` and `map/spawn.rs`