### PR TITLE
chore: fix outdated physics documentation regarding TiledCollider::Object

### DIFF
--- a/book/src/guides/physics.md
+++ b/book/src/guides/physics.md
@@ -163,7 +163,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(TiledMap(asset_server.load("map.tmx")))
         .observe(|collider_created: On<TiledEvent<ColliderCreated>>, mut commands: Commands| {
             // Filter collider created from Tiled objects
-            if collider_created.event().event.source == TiledCollider::Object {
+            if collider_created.event().event.source == TiledColliderSource::Object {
                 // Add a RigidBody::Static to the collider entity
                 commands
                     .entity(collider_created.event().origin)


### PR DESCRIPTION
While implementing the colliders for my game, I noticed this tiny issue. 

![](https://en.meming.world/images/en/b/be/But_It%27s_Honest_Work.jpg)